### PR TITLE
Refactor event handling to use per-block instances and simplify connection management

### DIFF
--- a/addons/flowkit/events/Node/on_ready.gd
+++ b/addons/flowkit/events/Node/on_ready.gd
@@ -10,34 +10,13 @@ func get_name() -> String:
 	return "On Ready"
 
 func get_supported_types() -> Array[String]:
-	return ["Node", "System"]
+	return ["Node"]
 
 func get_inputs() -> Array:
 	return []
 
-# Track which block IDs have already fired for on_ready
-var _fired_blocks: Dictionary = {}  # block_id -> true
-var _last_scene_path: String = ""
-
-
-func poll(node: Node, inputs: Dictionary = {}, block_id: String = "") -> bool:
-	if not node:
-		return false
-	
-	# Detect scene changes and reset tracking
-	var current_scene = node.get_tree().current_scene
-	if current_scene:
-		var scene_path = current_scene.scene_file_path
-		if scene_path != _last_scene_path:
-			_last_scene_path = scene_path
-			_fired_blocks.clear()
-	
-	# If this specific block has already fired, don't fire again
-	if block_id and _fired_blocks.has(block_id):
-		return false
-	
-	# Fire this block (first time we see it in this scene)
-	if block_id:
-		_fired_blocks[block_id] = true
-	
+func is_signal_event() -> bool:
 	return true
+
+func setup(node: Node, trigger_callback: Callable, block_id: String = "") -> void:
+	trigger_callback.call()

--- a/addons/flowkit/events/Timer/on_timeout.gd
+++ b/addons/flowkit/events/Timer/on_timeout.gd
@@ -15,20 +15,12 @@ func get_supported_types() -> Array[String]:
 func is_signal_event() -> bool:
 	return true
 
-# Store per-instance connection data: block_id -> { "node": Timer, "callback": Callable }
-var _connections: Dictionary = {}
+var _callback: Callable
 
 func setup(node: Node, trigger_callback: Callable, _block_id: String = "") -> void:
-	# Create a unique callback for this instance so multiple timers don't share state
-	var callback: Callable = func(): trigger_callback.call()
-	node.timeout.connect(callback)
-	_connections[_block_id] = { "node": node, "callback": callback }
+	_callback = func(): trigger_callback.call()
+	node.timeout.connect(_callback)
 
-func teardown(_node: Node, _block_id: String = "") -> void:
-	if _connections.has(_block_id):
-		var data: Dictionary = _connections[_block_id]
-		var stored_node: Node = data["node"]
-		var callback: Callable = data["callback"]
-		if is_instance_valid(stored_node) and stored_node.timeout.is_connected(callback):
-			stored_node.timeout.disconnect(callback)
-		_connections.erase(_block_id)
+func teardown(node: Node, _block_id: String = "") -> void:
+	if is_instance_valid(node) and node.timeout.is_connected(_callback):
+		node.timeout.disconnect(_callback)

--- a/addons/flowkit/events/UI/on_button_pressed.gd
+++ b/addons/flowkit/events/UI/on_button_pressed.gd
@@ -15,20 +15,12 @@ func get_supported_types() -> Array:
 func is_signal_event() -> bool:
 	return true
 
-# Store per-instance connection data: instance_id -> { "node": Button, "callback": Callable }
-var _connections: Dictionary = {}
+var _callback: Callable
 
 func setup(target_node: Node, trigger_callback: Callable, instance_id: String = "") -> void:
-	# Create a unique callback for this instance so multiple buttons don't share state
-	var callback: Callable = func(): trigger_callback.call()
-	target_node.pressed.connect(callback)
-	_connections[instance_id] = { "node": target_node, "callback": callback }
+	_callback = func(): trigger_callback.call()
+	target_node.pressed.connect(_callback)
 
 func teardown(target_node: Node, instance_id: String = "") -> void:
-	if _connections.has(instance_id):
-		var data: Dictionary = _connections[instance_id]
-		var node: Node = data["node"]
-		var callback: Callable = data["callback"]
-		if is_instance_valid(node) and node.pressed.is_connected(callback):
-			node.pressed.disconnect(callback)
-		_connections.erase(instance_id)
+	if is_instance_valid(target_node) and target_node.pressed.is_connected(_callback):
+		target_node.pressed.disconnect(_callback)

--- a/addons/flowkit/registry.gd
+++ b/addons/flowkit/registry.gd
@@ -125,6 +125,14 @@ func get_event_provider(event_id: String) -> Variant:
 			return provider
 	return null
 
+## Create a new, independent instance of the event provider for the given event_id.
+## Each event block should get its own instance to avoid shared state bugs.
+func create_event_instance(event_id: String) -> Variant:
+	for provider in event_providers:
+		if provider.has_method("get_id") and provider.get_id() == event_id:
+			return provider.get_script().new()
+	return null
+
 ## Call setup() on an event provider so it can connect to signals on the target node.
 ## trigger_callback is a Callable the provider can call to fire the block immediately.
 func setup_event(event_id: String, node: Node, trigger_callback: Callable, block_id: String = "") -> void:


### PR DESCRIPTION
This pull request introduces significant improvements to how event providers are managed in FlowKit, ensuring each event block gets its own isolated provider instance. This change eliminates shared state bugs and simplifies signal event connection management. The registry and engine have been updated to support per-block provider instantiation, and event provider scripts have been refactored to remove shared connection dictionaries in favor of per-instance callbacks.

**Event Provider Instance Isolation**
- Added `create_event_instance` to the registry and updated the engine to create a new provider instance for each event block, preventing shared state across blocks. [[1]](diffhunk://#diff-e9cdabdb3db8afa791d745060283c195fd3f7a05390d2183e138c0e58761a84eR128-R135) [[2]](diffhunk://#diff-5657c08082b030e98ecba3392625f3ec66d6f1c5638b2fb89dc83d5d82cef5dbR4-R10) [[3]](diffhunk://#diff-5657c08082b030e98ecba3392625f3ec66d6f1c5638b2fb89dc83d5d82cef5dbR125-R126) [[4]](diffhunk://#diff-5657c08082b030e98ecba3392625f3ec66d6f1c5638b2fb89dc83d5d82cef5dbR155-R172)

**Signal Event Connection Management Simplification**
- Refactored `on_timeout.gd` and `on_button_pressed.gd` to use a per-instance `_callback` instead of a shared connections dictionary, simplifying setup and teardown of signal connections. [[1]](diffhunk://#diff-b19fa63f23233b327238e3a19b2fb17bd8269269664419adb265ffe14328a9a0L18-R26) [[2]](diffhunk://#diff-75110d38b0cb8702f27d9e5f5cbc1e3fbf84910ea0e120fb0a0058bcc64be72bL18-R26)
- Updated teardown logic to disconnect only the relevant callback for each instance. [[1]](diffhunk://#diff-b19fa63f23233b327238e3a19b2fb17bd8269269664419adb265ffe14328a9a0L18-R26) [[2]](diffhunk://#diff-75110d38b0cb8702f27d9e5f5cbc1e3fbf84910ea0e120fb0a0058bcc64be72bL18-R26)

**Engine and Polling Logic Updates**
- Updated event polling and signal event setup/teardown in the engine to use per-block provider instances, ensuring correct method calls and isolation. [[1]](diffhunk://#diff-5657c08082b030e98ecba3392625f3ec66d6f1c5638b2fb89dc83d5d82cef5dbR229-R235) [[2]](diffhunk://#diff-5657c08082b030e98ecba3392625f3ec66d6f1c5638b2fb89dc83d5d82cef5dbL217-R250) [[3]](diffhunk://#diff-5657c08082b030e98ecba3392625f3ec66d6f1c5638b2fb89dc83d5d82cef5dbR272-R278) [[4]](diffhunk://#diff-5657c08082b030e98ecba3392625f3ec66d6f1c5638b2fb89dc83d5d82cef5dbL250-R290) [[5]](diffhunk://#diff-5657c08082b030e98ecba3392625f3ec66d6f1c5638b2fb89dc83d5d82cef5dbR305-R318)
- Cleared the provider instance map on scene change to avoid stale references.

**Event Script Cleanup**
- Refactored `on_ready.gd` to remove block firing tracking logic, now relying on per-instance setup for signal events.

These changes collectively improve the reliability and maintainability of event handling in FlowKit.