### PR TITLE
Extracting Undo/Redo Logic into FKUndoManager

### DIFF
--- a/addons/flowkit/editor/undo_manager.gd
+++ b/addons/flowkit/editor/undo_manager.gd
@@ -1,0 +1,36 @@
+extends RefCounted
+class_name FKUndoManager
+
+const MAX_UNDO_STATES: int = 50
+
+var _undo_stack: Array = []
+var _redo_stack: Array = []
+
+func clear() -> void:
+	_undo_stack.clear()
+	_redo_stack.clear()
+
+func can_undo() -> bool:
+	return not _undo_stack.is_empty()
+
+func can_redo() -> bool:
+	return not _redo_stack.is_empty()
+
+func push_state(state: Array) -> void:
+	# Store a deep copy so later mutations don't affect history
+	_undo_stack.append(state.duplicate(true))
+	while _undo_stack.size() > MAX_UNDO_STATES:
+		_undo_stack.pop_front()
+	_redo_stack.clear()
+
+func undo(current_state: Array) -> Array:
+	if _undo_stack.is_empty():
+		return current_state
+	_redo_stack.append(current_state.duplicate(true))
+	return _undo_stack.pop_back()
+
+func redo(current_state: Array) -> Array:
+	if _redo_stack.is_empty():
+		return current_state
+	_undo_stack.append(current_state.duplicate(true))
+	return _redo_stack.pop_back()

--- a/addons/flowkit/editor/undo_manager.gd.uid
+++ b/addons/flowkit/editor/undo_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://b3xj4lck5vbm6


### PR DESCRIPTION
This PR begins a series of small, low‑risk refactors aimed at reducing the size and responsibility of editor.gd. The undo/redo system is one of the most self‑contained parts of the file, so it makes a good starting point.

# What this PR does
- Introduces a new helper class: FKUndoManager, responsible for storing undo/redo stacks and managing state transitions.
- Moves all stack bookkeeping (undo_stack, redo_stack, max size enforcement, clearing, etc.) out of editor.gd.
- Updates editor.gd so it:
  - Delegates stack operations to FKUndoManager
  - Keeps ownership of _capture_sheet_state() and _restore_sheet_state()
  - Keeps the keyboard shortcuts and UI triggers unchanged

# Why this is useful
- Reduces the size and complexity of editor.gd
- Makes undo/redo behavior easier to test and understand
- Keeps the PR small and reviewable
  - No functional changes beyond moving logic
- The more modular the editor implementation gets, the easier it'll be to extend it

# Implementation Notes
- editor.gd now holds `var undo_manager := FKUndoManager.new()`, with all previous direct stack manipulation replaced with calls to the new manager
