### PR TITLE
Delete and paste fix

### DIFF
--- a/addons/flowkit/ui/editor.gd
+++ b/addons/flowkit/ui/editor.gd
@@ -697,10 +697,7 @@ func _paste_events_from_clipboard() -> void:
 			
 			# Restore actions
 			for act_dict in event_data_dict["actions"]:
-				var act = FKEventAction.new()
-				act.action_id = act_dict["action_id"]
-				act.target_node = act_dict["target_node"]
-				act.inputs = act_dict["inputs"].duplicate()
+				var act = _deserialize_action(act_dict)
 				data.actions.append(act)
 			
 			# Add to group via the group's method
@@ -739,10 +736,7 @@ func _paste_events_from_clipboard() -> void:
 		
 		# Restore actions
 		for act_dict in event_data_dict["actions"]:
-			var act = FKEventAction.new()
-			act.action_id = act_dict["action_id"]
-			act.target_node = act_dict["target_node"]
-			act.inputs = act_dict["inputs"].duplicate()
+			var act = _deserialize_action(act_dict)
 			data.actions.append(act)
 		
 		var new_row = _create_event_row(data)


### PR DESCRIPTION
This pull request improves the robustness and usability of clipboard paste operations and row deletion in the `editor.gd` UI script. The main focus is on ensuring correct handling for different row types, improving user feedback, and maintaining selection consistency after paste actions.

**Clipboard Paste Improvements:**

* Refactored action deserialization during event and group pasting to use a dedicated `_deserialize_action` method, ensuring consistent and centralized action creation logic. [[1]](diffhunk://#diff-26ab7c37eeb86b9a534cbc6aabd282af2f4e99d0192d16f36f9037975b2740c6L692-R700) [[2]](diffhunk://#diff-26ab7c37eeb86b9a534cbc6aabd282af2f4e99d0192d16f36f9037975b2740c6L734-R739)
* Added type checks before pasting actions or conditions to ensure the selected row is an event, with user feedback if not, preventing invalid operations. [[1]](diffhunk://#diff-26ab7c37eeb86b9a534cbc6aabd282af2f4e99d0192d16f36f9037975b2740c6R801-R808) [[2]](diffhunk://#diff-26ab7c37eeb86b9a534cbc6aabd282af2f4e99d0192d16f36f9037975b2740c6R852-R855)

**UI/UX Enhancements:**

* After pasting actions or conditions, the target row is now re-selected to ensure selection persists and the UI remains intuitive. [[1]](diffhunk://#diff-26ab7c37eeb86b9a534cbc6aabd282af2f4e99d0192d16f36f9037975b2740c6L815-R825) [[2]](diffhunk://#diff-26ab7c37eeb86b9a534cbc6aabd282af2f4e99d0192d16f36f9037975b2740c6L859-R874)

**Row Deletion Logic:**

* Improved row deletion by emitting the correct delete signal depending on whether the row is a group, comment, or event, ensuring proper handling for nested and specialized row types.

**Code Quality:**

* Minor cleanup: added a blank line at the end of `_find_event_row_at_mouse` for consistency.