### PR TITLE
Streamline Editor Architecture: Sheet Ordering, UI Lookup, and UnitUi Factory

### DIFF
--- a/addons/flowkit/editor/Ui/base_unit_ui.gd
+++ b/addons/flowkit/editor/Ui/base_unit_ui.gd
@@ -2,10 +2,10 @@
 extends MarginContainer
 class_name FKUnitUi
 
-signal before_block_changed(node)
-signal block_changed(node)
+signal before_block_changed(node: FKUnitUi)
+signal block_changed(node: FKUnitUi)
 signal block_contents_changed()
-signal selected(node)
+signal selected(node: FKUnitUi)
 
 ## Call this when you want to have an FKUnitUi work properly as
 ## a non-preview instance. This func assumes this instance
@@ -44,6 +44,7 @@ func _ready() -> void:
 	mouse_filter = Control.MOUSE_FILTER_STOP
 	update_display.call_deferred()
 	
+## Returns the FKUnit this is representing.
 func get_block() -> FKUnit:
 	return _block
 

--- a/addons/flowkit/editor/Ui/comment_ui.gd
+++ b/addons/flowkit/editor/Ui/comment_ui.gd
@@ -186,7 +186,10 @@ func _can_drop_data(at_position: Vector2, data) -> bool:
 		var parent = get_parent()
 		if parent and parent.has_method("_can_drop_data"):
 			var parent_pos = at_position + position
-			return parent._can_drop_data(parent_pos, data)
+			#print("[FKCommentUi] Delegating to parent's (" + parent.name + "'s) _can_drop_data")
+			var result: bool = parent._can_drop_data(parent_pos, data)
+			#print("Result: " + str(result))
+			return result
 	
 	return false
 
@@ -197,14 +200,17 @@ func _drop_data(at_position: Vector2, data) -> void:
 		return
 		
 	var drag_data = data as FKDragData
-	
+	#print("[FKCommentUi] Drag data type given in _drop_data: " + drag_data.type)
 	# For event_row, comment, or group drags, forward to parent
-	if drag_data.type in [DragTarget.Type.EVENT_ROW, DragTarget.Type.COMMENT, \
-	DragTarget.Type.GROUP]:
+	if drag_data.type in _drag_targets:
 		var parent = get_parent()
 		if parent and parent.has_method("_drop_data"):
 			var parent_pos = at_position + position
+			#print("[FKCommentUi] Dropping at pos " + str(parent_pos))
 			parent._drop_data(parent_pos, data)
+
+static var _drag_targets := [DragTarget.Type.EVENT_ROW, DragTarget.Type.COMMENT, \
+	DragTarget.Type.GROUP]
 
 func _on_right_click(event: InputEventMouseButton):
 	_show_context_menu(event.global_position)

--- a/addons/flowkit/editor/Ui/unit_ui_factory.gd
+++ b/addons/flowkit/editor/Ui/unit_ui_factory.gd
@@ -1,0 +1,61 @@
+extends Node
+class_name FKUnitUiFactory
+
+func _init(p_sheet_io: FKSheetIO) -> void:
+	sheet_io = p_sheet_io
+	
+var sheet_io : FKSheetIO 
+var registry: FKRegistry
+
+##
+## Currently only able to output these:
+## FKEventRowUi
+## FKCommentUi
+#3 FKGroupUi
+##
+func unit_ui_from(unit: FKUnit, inputs: Dictionary = {}) -> FKUnitUi:
+	var result: FKUnitUi = null
+	
+	if unit is FKEventBlock:
+		result = _create_event_row(unit)
+	elif unit is FKComment:
+		result = _create_comment_ui(unit)
+	elif unit is FKGroup:
+		result = _create_group_block(unit)
+		
+	return result
+		
+	
+func _create_event_row(data: FKEventBlock) -> FKEventRowUi:
+	"""Create event row node from data (GDevelop-style)."""
+	#print("[FKUnitUiFactory] Creating event row node")
+	var row: FKEventRowUi = EVENT_ROW_SCENE.instantiate()
+	var copy := sheet_io.copy_event_block(data)
+	
+	row.legitimize(copy, registry)
+	return row
+	
+const EVENT_ROW_SCENE = preload("res://addons/flowkit/ui/workspace/event_row_ui.tscn")
+
+func _create_comment_ui(data: FKComment) -> FKCommentUi:
+	"""Create comment block node from data."""
+	#print("[FKUnitUiFactory]: Creating comment block node")
+	var comment: FKCommentUi = COMMENT_SCENE.instantiate()
+	var copy := FKComment.new()
+	copy.text = data.text
+	
+	comment.legitimize(copy, registry)
+	return comment
+
+const COMMENT_SCENE = preload("res://addons/flowkit/ui/workspace/comment_ui.tscn")
+
+func _create_group_block(data: FKGroup) -> FKGroupUi:
+	"""Create group block node from data."""
+	#print("[FKUnitUiFactory]: Creating group block node")
+	var group: FKGroupUi = GROUP_SCENE.instantiate()
+	var copy := data.copy_deep()
+	copy.normalize_children()
+	group.legitimize(copy, registry)
+	return group
+	
+const GROUP_SCENE = preload("res://addons/flowkit/ui/workspace/group_ui.tscn")

--- a/addons/flowkit/editor/Ui/unit_ui_factory.gd.uid
+++ b/addons/flowkit/editor/Ui/unit_ui_factory.gd.uid
@@ -1,0 +1,1 @@
+uid://dpobeetfqwbo1

--- a/addons/flowkit/editor/editor_globals.gd
+++ b/addons/flowkit/editor/editor_globals.gd
@@ -3,8 +3,8 @@ class_name FKEditorGlobals
 
 const EVENT_ROW_SCENE := preload("res://addons/flowkit/ui/workspace/event_row_ui.tscn")
 const COMMENT_SCENE := preload("res://addons/flowkit/ui/workspace/comment_ui.tscn")
-const CONDITION_ITEM_SCENE := preload("res://addons/flowkit/ui/workspace/condition_item_ui.tscn")
+const CONDITION_ITEM_SCENE := preload("res://addons/flowkit/ui/workspace/condition_unit_ui.tscn")
 const ACTION_ITEM_SCENE := preload("res://addons/flowkit/ui/workspace/action_unit_ui.tscn")
 
-const BRANCH_ITEM_SCENE_PATH := "res://addons/flowkit/ui/workspace/branch_item_ui.tscn"
+const BRANCH_ITEM_SCENE_PATH := "res://addons/flowkit/ui/workspace/branch_unit_ui.tscn"
 const BRANCH_ITEM_SCENE := preload(BRANCH_ITEM_SCENE_PATH)

--- a/addons/flowkit/editor/main_editor_input_handler.gd
+++ b/addons/flowkit/editor/main_editor_input_handler.gd
@@ -8,7 +8,7 @@ func initialize(main_ed: FKMainEditor):
 	
 var _editor: FKMainEditor
 var clipboard: FKClipboardManager
-var block_container: BlockContainerUi
+var block_container: FKBlockContainerUi
 
 func handle_input(event: InputEvent):
 	var is_left_click: bool = event is InputEventMouseButton and event.pressed and \

--- a/addons/flowkit/editor/sheet_io.gd
+++ b/addons/flowkit/editor/sheet_io.gd
@@ -21,6 +21,7 @@ func load_sheet(scene_uid: int) -> FKEventSheet:
 func save_sheet(scene_uid: int, sheet: FKEventSheet) -> int:
 	var sheet_path := get_sheet_path(scene_uid)
 	if sheet_path == "":
+		print("[SheetIo] Returning err invalid param")
 		return ERR_INVALID_PARAMETER
 
 	DirAccess.make_dir_recursive_absolute(SHEET_DIR)

--- a/addons/flowkit/resources/event_sheet.gd
+++ b/addons/flowkit/resources/event_sheet.gd
@@ -1,3 +1,4 @@
+@tool
 extends Resource
 class_name FKEventSheet
 ## The main event sheet resource that stores all events, comments, and groups for a scene.
@@ -96,7 +97,7 @@ func get_ordered_items() -> Array:
 	
 	return items
 
-static func from_copies_of(units: Array[FKUnit]) -> FKEventSheet:
+static func from_units(units: Array[FKUnit]) -> FKEventSheet:
 	var sheet := FKEventSheet.new()
 	for elem in units:
 		sheet.append_copy_of(elem)

--- a/addons/flowkit/resources/event_sheet.gd
+++ b/addons/flowkit/resources/event_sheet.gd
@@ -14,6 +14,35 @@ class_name FKEventSheet
 ## Stores the display order: [{"type": "event"|"comment"|"group", "index": int}, ...]
 @export var item_order: Array[Dictionary] = []
 
+## Returns an array of the top-level FKUnits in the order they were
+## appended to this sheet.
+var ordered_items: Array[FKUnit]:
+	get:
+		if _ordered_items.size() != item_order.size():
+			_refresh_ordered_items()
+			
+		return _ordered_items
+			
+func _refresh_ordered_items():
+	_ordered_items.clear()
+	
+	for item in item_order:
+		var item_type = item.get("type", "")
+		var item_index: int = item.get("index", 0)
+		var to_add: FKUnit = null
+		
+		if item_type == "event" and item_index < events.size():
+			to_add = events[item_index]
+		elif item_type == "comment" and item_index < comments.size():
+			to_add = comments[item_index]
+		elif item_type == "group" and item_index < groups.size():
+			to_add = groups[item_index]
+			
+		if to_add:
+			_ordered_items.append(to_add)
+			
+var _ordered_items: Array[FKUnit] = []
+
 func get_all_events() -> Array:
 	var events := []
 	events.append_array(self.events)
@@ -67,7 +96,49 @@ func get_ordered_items() -> Array:
 	
 	return items
 
+static func from_copies_of(units: Array[FKUnit]) -> FKEventSheet:
+	var sheet := FKEventSheet.new()
+	for elem in units:
+		sheet.append_copy_of(elem)
+	return sheet
 
+## Updates the item order as well.
+func append_copy_of(unit: FKUnit):
+	var copy := unit.duplicate_block()
+	
+	var where_copy_goes: Array = _array_for(copy)
+	where_copy_goes.append(copy)
+	
+	var order_to_append: Dictionary = \
+	{
+		"type": copy.block_type,
+		"index": where_copy_goes.size() - 1
+	}
+	item_order.append(order_to_append)
+
+## Returns the array in this sheet that the passed unit is able to go into
+func _array_for(unit: FKUnit) -> Array:
+	var result: Array = []
+	
+	if unit is FKEventBlock:
+		result = events
+		#print("[FKEventSheet] chosen arr: events")
+	elif unit is FKComment:
+		result = comments
+		#print("[FKEventSheet] chosen arr: comments")
+	elif unit is FKGroup:
+		result = groups
+		#print("[FKEventSheet] chosen arr: groups")
+	elif unit is FKConditionUnit: 
+		# Seems you can't have a top-level FKConditionUnit, but just in 
+		# case for the future...
+		result = standalone_conditions
+		#print("[FKEventSheet] chosen arr: standalone_conditions")
+	else:
+		print("[FKEventSheet] Unknown block type we can't register: " + unit.block_type)
+	
+	return result
+	
 func rebuild_order_from_items(ordered_items: Array) -> void:
 	"""Rebuild the events, comments, groups arrays and item_order from an ordered list."""
 	events = [] as Array[FKEventBlock]

--- a/addons/flowkit/runtime/Units/condition_unit.gd
+++ b/addons/flowkit/runtime/Units/condition_unit.gd
@@ -33,6 +33,7 @@ func duplicate_block() -> FKUnit:
 	result.target_node = str(target_node)
 	result.inputs = inputs.duplicate()
 	result.negated = negated
+	result.actions = [] as Array[FKActionUnit]
 	
 	return result
 	

--- a/addons/flowkit/saved/event_sheet/7830454191141003914.tres
+++ b/addons/flowkit/saved/event_sheet/7830454191141003914.tres
@@ -8,6 +8,11 @@
 [ext_resource type="Script" uid="uid://bumsyiqkp46l1" path="res://addons/flowkit/resources/event_sheet.gd" id="6_rpy5k"]
 
 [sub_resource type="Resource" id="Resource_df7pu"]
+script = ExtResource("1_e8buc")
+text = "Yep, it's Godot trivia!"
+block_type = "comment"
+
+[sub_resource type="Resource" id="Resource_uoxok"]
 script = ExtResource("3_j21vh")
 action_id = "set_window_mode"
 target_node = NodePath("System")
@@ -16,7 +21,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_uoxok"]
+[sub_resource type="Resource" id="Resource_j21vh"]
 script = ExtResource("3_j21vh")
 action_id = "set_window_size"
 target_node = NodePath("System")
@@ -26,7 +31,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_j21vh"]
+[sub_resource type="Resource" id="Resource_emcdn"]
 script = ExtResource("3_j21vh")
 action_id = "Wait For Frames"
 target_node = NodePath("System")
@@ -35,7 +40,16 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_emcdn"]
+[sub_resource type="Resource" id="Resource_ulxaw"]
+script = ExtResource("3_j21vh")
+action_id = "set_window_mode"
+target_node = NodePath("System")
+inputs = {
+"Mode": "windowed"
+}
+block_type = "action"
+
+[sub_resource type="Resource" id="Resource_rpy5k"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -45,7 +59,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_ulxaw"]
+[sub_resource type="Resource" id="Resource_efrgi"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -55,7 +69,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_rpy5k"]
+[sub_resource type="Resource" id="Resource_e6bne"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -65,7 +79,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_efrgi"]
+[sub_resource type="Resource" id="Resource_1h0yk"]
 script = ExtResource("3_j21vh")
 action_id = "Set Text"
 target_node = NodePath("DisplaysQuestion/QuestionText")
@@ -74,7 +88,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_e6bne"]
+[sub_resource type="Resource" id="Resource_7gjgi"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -84,7 +98,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_1h0yk"]
+[sub_resource type="Resource" id="Resource_njo67"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -94,7 +108,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_7gjgi"]
+[sub_resource type="Resource" id="Resource_7p70r"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -104,7 +118,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_njo67"]
+[sub_resource type="Resource" id="Resource_jl3cs"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -114,7 +128,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_7p70r"]
+[sub_resource type="Resource" id="Resource_y38jp"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -124,7 +138,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_jl3cs"]
+[sub_resource type="Resource" id="Resource_6grxg"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -134,7 +148,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_y38jp"]
+[sub_resource type="Resource" id="Resource_jpbjx"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -144,7 +158,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_6grxg"]
+[sub_resource type="Resource" id="Resource_ewbs2"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -154,7 +168,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_jpbjx"]
+[sub_resource type="Resource" id="Resource_7e0ye"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -164,7 +178,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_ewbs2"]
+[sub_resource type="Resource" id="Resource_yayi7"]
 script = ExtResource("3_j21vh")
 action_id = "Set Text"
 target_node = NodePath("HoldsAnswers/FirstAnswerButton")
@@ -173,7 +187,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_7e0ye"]
+[sub_resource type="Resource" id="Resource_4t33x"]
 script = ExtResource("3_j21vh")
 action_id = "Set Text"
 target_node = NodePath("HoldsAnswers/SecondAnswerButton")
@@ -182,7 +196,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_yayi7"]
+[sub_resource type="Resource" id="Resource_3wu3y"]
 script = ExtResource("3_j21vh")
 action_id = "Set Text"
 target_node = NodePath("HoldsAnswers/ThirdAnswerButton")
@@ -191,7 +205,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_4t33x"]
+[sub_resource type="Resource" id="Resource_8wvsr"]
 script = ExtResource("3_j21vh")
 action_id = "Set Text"
 target_node = NodePath("HoldsAnswers/FourthAnswerButton")
@@ -200,7 +214,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_3wu3y"]
+[sub_resource type="Resource" id="Resource_apwru"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -210,7 +224,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_8wvsr"]
+[sub_resource type="Resource" id="Resource_yrydo"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -220,7 +234,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_apwru"]
+[sub_resource type="Resource" id="Resource_hlcqt"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -230,7 +244,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_yrydo"]
+[sub_resource type="Resource" id="Resource_cfel1"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -240,7 +254,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_hlcqt"]
+[sub_resource type="Resource" id="Resource_fe1w8"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -250,7 +264,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_cfel1"]
+[sub_resource type="Resource" id="Resource_e0fgu"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -260,7 +274,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_fe1w8"]
+[sub_resource type="Resource" id="Resource_t47qt"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -270,7 +284,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_e0fgu"]
+[sub_resource type="Resource" id="Resource_icjx7"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -280,7 +294,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_t47qt"]
+[sub_resource type="Resource" id="Resource_o3aem"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -290,7 +304,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_icjx7"]
+[sub_resource type="Resource" id="Resource_bmqy2"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -300,7 +314,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_o3aem"]
+[sub_resource type="Resource" id="Resource_7fkax"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -310,7 +324,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_bmqy2"]
+[sub_resource type="Resource" id="Resource_f6ogq"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -320,7 +334,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_7fkax"]
+[sub_resource type="Resource" id="Resource_gajsv"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -330,7 +344,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_f6ogq"]
+[sub_resource type="Resource" id="Resource_e5g1r"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -340,7 +354,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_gajsv"]
+[sub_resource type="Resource" id="Resource_3pq7a"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -350,15 +364,15 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_e5g1r"]
+[sub_resource type="Resource" id="Resource_e3r8u"]
 script = ExtResource("2_uoxok")
-block_id = "event_1775659447_3672557272"
+block_id = "event_1775935370_3651881096"
 event_id = "on_ready"
 target_node = NodePath(".")
-actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_df7pu"), SubResource("Resource_uoxok"), SubResource("Resource_j21vh"), SubResource("Resource_emcdn"), SubResource("Resource_ulxaw"), SubResource("Resource_rpy5k"), SubResource("Resource_efrgi"), SubResource("Resource_e6bne"), SubResource("Resource_1h0yk"), SubResource("Resource_7gjgi"), SubResource("Resource_njo67"), SubResource("Resource_7p70r"), SubResource("Resource_jl3cs"), SubResource("Resource_y38jp"), SubResource("Resource_6grxg"), SubResource("Resource_jpbjx"), SubResource("Resource_ewbs2"), SubResource("Resource_7e0ye"), SubResource("Resource_yayi7"), SubResource("Resource_4t33x"), SubResource("Resource_3wu3y"), SubResource("Resource_8wvsr"), SubResource("Resource_apwru"), SubResource("Resource_yrydo"), SubResource("Resource_hlcqt"), SubResource("Resource_cfel1"), SubResource("Resource_fe1w8"), SubResource("Resource_e0fgu"), SubResource("Resource_t47qt"), SubResource("Resource_icjx7"), SubResource("Resource_o3aem"), SubResource("Resource_bmqy2"), SubResource("Resource_7fkax"), SubResource("Resource_f6ogq"), SubResource("Resource_gajsv")])
+actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_uoxok"), SubResource("Resource_j21vh"), SubResource("Resource_emcdn"), SubResource("Resource_ulxaw"), SubResource("Resource_rpy5k"), SubResource("Resource_efrgi"), SubResource("Resource_e6bne"), SubResource("Resource_1h0yk"), SubResource("Resource_7gjgi"), SubResource("Resource_njo67"), SubResource("Resource_7p70r"), SubResource("Resource_jl3cs"), SubResource("Resource_y38jp"), SubResource("Resource_6grxg"), SubResource("Resource_jpbjx"), SubResource("Resource_ewbs2"), SubResource("Resource_7e0ye"), SubResource("Resource_yayi7"), SubResource("Resource_4t33x"), SubResource("Resource_3wu3y"), SubResource("Resource_8wvsr"), SubResource("Resource_apwru"), SubResource("Resource_yrydo"), SubResource("Resource_hlcqt"), SubResource("Resource_cfel1"), SubResource("Resource_fe1w8"), SubResource("Resource_e0fgu"), SubResource("Resource_t47qt"), SubResource("Resource_icjx7"), SubResource("Resource_o3aem"), SubResource("Resource_bmqy2"), SubResource("Resource_7fkax"), SubResource("Resource_f6ogq"), SubResource("Resource_gajsv"), SubResource("Resource_e5g1r"), SubResource("Resource_3pq7a")])
 block_type = "event"
 
-[sub_resource type="Resource" id="Resource_3pq7a"]
+[sub_resource type="Resource" id="Resource_vvbgy"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -368,7 +382,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_e3r8u"]
+[sub_resource type="Resource" id="Resource_x3kut"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -378,13 +392,13 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_vvbgy"]
+[sub_resource type="Resource" id="Resource_2q5cv"]
 script = ExtResource("3_j21vh")
 action_id = "play"
 target_node = NodePath("CorrectVoiceClip")
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_x3kut"]
+[sub_resource type="Resource" id="Resource_4rioj"]
 script = ExtResource("4_s7nm7")
 condition_id = "compare_variable"
 target_node = NodePath("System")
@@ -395,28 +409,28 @@ inputs = {
 }
 block_type = "condition"
 
-[sub_resource type="Resource" id="Resource_2q5cv"]
+[sub_resource type="Resource" id="Resource_cpo3s"]
 script = ExtResource("3_j21vh")
 is_branch = true
 branch_type = "if"
-branch_condition = SubResource("Resource_x3kut")
-branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_e3r8u"), SubResource("Resource_vvbgy")])
+branch_condition = SubResource("Resource_4rioj")
+branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_x3kut"), SubResource("Resource_2q5cv")])
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_4rioj"]
+[sub_resource type="Resource" id="Resource_crlsd"]
 script = ExtResource("3_j21vh")
 action_id = "play"
 target_node = NodePath("INcorrectVoiceClip")
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_cpo3s"]
+[sub_resource type="Resource" id="Resource_ulr6u"]
 script = ExtResource("3_j21vh")
 is_branch = true
 branch_type = "else"
-branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_4rioj")])
+branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_crlsd")])
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_crlsd"]
+[sub_resource type="Resource" id="Resource_iud1s"]
 script = ExtResource("3_j21vh")
 action_id = "Print Message"
 target_node = NodePath(".")
@@ -426,15 +440,15 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_ulr6u"]
+[sub_resource type="Resource" id="Resource_wccxq"]
 script = ExtResource("2_uoxok")
-block_id = "event_1775659447_3464841607"
+block_id = "event_1775935370_2187878724"
 event_id = "On Button Pressed"
 target_node = NodePath("HoldsAnswers/FirstAnswerButton")
-actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_3pq7a"), SubResource("Resource_2q5cv"), SubResource("Resource_cpo3s"), SubResource("Resource_crlsd")])
+actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_vvbgy"), SubResource("Resource_cpo3s"), SubResource("Resource_ulr6u"), SubResource("Resource_iud1s")])
 block_type = "event"
 
-[sub_resource type="Resource" id="Resource_iud1s"]
+[sub_resource type="Resource" id="Resource_77cye"]
 script = ExtResource("3_j21vh")
 action_id = "Print Message"
 target_node = NodePath(".")
@@ -444,7 +458,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_wccxq"]
+[sub_resource type="Resource" id="Resource_e0h2c"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -454,7 +468,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_77cye"]
+[sub_resource type="Resource" id="Resource_fql5c"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -464,13 +478,13 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_e0h2c"]
+[sub_resource type="Resource" id="Resource_jvbn4"]
 script = ExtResource("3_j21vh")
 action_id = "play"
 target_node = NodePath("CorrectVoiceClip")
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_fql5c"]
+[sub_resource type="Resource" id="Resource_2i8k8"]
 script = ExtResource("4_s7nm7")
 condition_id = "compare_variable"
 target_node = NodePath("System")
@@ -481,36 +495,36 @@ inputs = {
 }
 block_type = "condition"
 
-[sub_resource type="Resource" id="Resource_jvbn4"]
+[sub_resource type="Resource" id="Resource_jj233"]
 script = ExtResource("3_j21vh")
 is_branch = true
 branch_type = "if"
-branch_condition = SubResource("Resource_fql5c")
-branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_77cye"), SubResource("Resource_e0h2c")])
+branch_condition = SubResource("Resource_2i8k8")
+branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_fql5c"), SubResource("Resource_jvbn4")])
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_2i8k8"]
+[sub_resource type="Resource" id="Resource_0gvro"]
 script = ExtResource("3_j21vh")
 action_id = "play"
 target_node = NodePath("INcorrectVoiceClip")
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_jj233"]
+[sub_resource type="Resource" id="Resource_v6ggk"]
 script = ExtResource("3_j21vh")
 is_branch = true
 branch_type = "else"
-branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_2i8k8")])
+branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_0gvro")])
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_0gvro"]
+[sub_resource type="Resource" id="Resource_2ae07"]
 script = ExtResource("2_uoxok")
-block_id = "event_1775659447_3107014360"
+block_id = "event_1775935370_2123418729"
 event_id = "On Button Pressed"
 target_node = NodePath("HoldsAnswers/SecondAnswerButton")
-actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_iud1s"), SubResource("Resource_wccxq"), SubResource("Resource_jvbn4"), SubResource("Resource_jj233")])
+actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_77cye"), SubResource("Resource_e0h2c"), SubResource("Resource_jj233"), SubResource("Resource_v6ggk")])
 block_type = "event"
 
-[sub_resource type="Resource" id="Resource_v6ggk"]
+[sub_resource type="Resource" id="Resource_en1qb"]
 script = ExtResource("3_j21vh")
 action_id = "Print Message"
 target_node = NodePath(".")
@@ -520,7 +534,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_2ae07"]
+[sub_resource type="Resource" id="Resource_4a7op"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -530,7 +544,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_en1qb"]
+[sub_resource type="Resource" id="Resource_jvhj0"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -540,13 +554,13 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_4a7op"]
+[sub_resource type="Resource" id="Resource_18u5c"]
 script = ExtResource("3_j21vh")
 action_id = "play"
 target_node = NodePath("CorrectVoiceClip")
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_jvhj0"]
+[sub_resource type="Resource" id="Resource_a5vmf"]
 script = ExtResource("4_s7nm7")
 condition_id = "compare_variable"
 target_node = NodePath("System")
@@ -557,36 +571,36 @@ inputs = {
 }
 block_type = "condition"
 
-[sub_resource type="Resource" id="Resource_18u5c"]
+[sub_resource type="Resource" id="Resource_lp0wt"]
 script = ExtResource("3_j21vh")
 is_branch = true
 branch_type = "if"
-branch_condition = SubResource("Resource_jvhj0")
-branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_en1qb"), SubResource("Resource_4a7op")])
+branch_condition = SubResource("Resource_a5vmf")
+branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_jvhj0"), SubResource("Resource_18u5c")])
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_a5vmf"]
+[sub_resource type="Resource" id="Resource_gekfw"]
 script = ExtResource("3_j21vh")
 action_id = "play"
 target_node = NodePath("INcorrectVoiceClip")
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_lp0wt"]
+[sub_resource type="Resource" id="Resource_a6awu"]
 script = ExtResource("3_j21vh")
 is_branch = true
 branch_type = "else"
-branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_a5vmf")])
+branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_gekfw")])
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_gekfw"]
+[sub_resource type="Resource" id="Resource_m718d"]
 script = ExtResource("2_uoxok")
-block_id = "event_1775659447_1974639899"
+block_id = "event_1775935370_2070493434"
 event_id = "On Button Pressed"
 target_node = NodePath("HoldsAnswers/ThirdAnswerButton")
-actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_v6ggk"), SubResource("Resource_2ae07"), SubResource("Resource_18u5c"), SubResource("Resource_lp0wt")])
+actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_en1qb"), SubResource("Resource_4a7op"), SubResource("Resource_lp0wt"), SubResource("Resource_a6awu")])
 block_type = "event"
 
-[sub_resource type="Resource" id="Resource_a6awu"]
+[sub_resource type="Resource" id="Resource_l7q4j"]
 script = ExtResource("3_j21vh")
 action_id = "Print Message"
 target_node = NodePath(".")
@@ -596,7 +610,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_m718d"]
+[sub_resource type="Resource" id="Resource_v4uwj"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -606,7 +620,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_l7q4j"]
+[sub_resource type="Resource" id="Resource_qjnoe"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -616,13 +630,13 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_v4uwj"]
+[sub_resource type="Resource" id="Resource_uvq0u"]
 script = ExtResource("3_j21vh")
 action_id = "play"
 target_node = NodePath("CorrectVoiceClip")
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_qjnoe"]
+[sub_resource type="Resource" id="Resource_ht44d"]
 script = ExtResource("4_s7nm7")
 condition_id = "compare_variable"
 target_node = NodePath("System")
@@ -633,36 +647,36 @@ inputs = {
 }
 block_type = "condition"
 
-[sub_resource type="Resource" id="Resource_uvq0u"]
+[sub_resource type="Resource" id="Resource_bieu4"]
 script = ExtResource("3_j21vh")
 is_branch = true
 branch_type = "if"
-branch_condition = SubResource("Resource_qjnoe")
-branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_l7q4j"), SubResource("Resource_v4uwj")])
+branch_condition = SubResource("Resource_ht44d")
+branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_qjnoe"), SubResource("Resource_uvq0u")])
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_ht44d"]
+[sub_resource type="Resource" id="Resource_po1c6"]
 script = ExtResource("3_j21vh")
 action_id = "play"
 target_node = NodePath("INcorrectVoiceClip")
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_bieu4"]
+[sub_resource type="Resource" id="Resource_6m3qi"]
 script = ExtResource("3_j21vh")
 is_branch = true
 branch_type = "else"
-branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_ht44d")])
+branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_po1c6")])
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_po1c6"]
+[sub_resource type="Resource" id="Resource_pcxsw"]
 script = ExtResource("2_uoxok")
-block_id = "event_1775659447_126874220"
+block_id = "event_1775935370_1175266552"
 event_id = "On Button Pressed"
 target_node = NodePath("HoldsAnswers/FourthAnswerButton")
-actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_a6awu"), SubResource("Resource_m718d"), SubResource("Resource_uvq0u"), SubResource("Resource_bieu4")])
+actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_l7q4j"), SubResource("Resource_v4uwj"), SubResource("Resource_bieu4"), SubResource("Resource_6m3qi")])
 block_type = "event"
 
-[sub_resource type="Resource" id="Resource_6m3qi"]
+[sub_resource type="Resource" id="Resource_4gecw"]
 script = ExtResource("3_j21vh")
 action_id = "Print Message"
 target_node = NodePath(".")
@@ -672,18 +686,22 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_pcxsw"]
+[sub_resource type="Resource" id="Resource_7afg8"]
 script = ExtResource("2_uoxok")
-block_id = "event_1775659447_558483279"
+block_id = "event_1775935370_3956383849"
 event_id = "On Text Changed"
 target_node = NodePath("HoldsAnswers/FirstAnswerButton")
-actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_6m3qi")])
+actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_4gecw")])
 block_type = "event"
 
 [resource]
 script = ExtResource("6_rpy5k")
-events = Array[ExtResource("2_uoxok")]([SubResource("Resource_e5g1r"), SubResource("Resource_ulr6u"), SubResource("Resource_0gvro"), SubResource("Resource_gekfw"), SubResource("Resource_po1c6"), SubResource("Resource_pcxsw")])
+events = Array[ExtResource("2_uoxok")]([SubResource("Resource_e3r8u"), SubResource("Resource_wccxq"), SubResource("Resource_2ae07"), SubResource("Resource_m718d"), SubResource("Resource_pcxsw"), SubResource("Resource_7afg8")])
+comments = Array[ExtResource("1_e8buc")]([SubResource("Resource_df7pu")])
 item_order = Array[Dictionary]([{
+"index": 0,
+"type": "comment"
+}, {
 "index": 0,
 "type": "event"
 }, {

--- a/addons/flowkit/ui/blocks_container_ui.gd
+++ b/addons/flowkit/ui/blocks_container_ui.gd
@@ -1,6 +1,6 @@
 @tool
 extends VBoxContainer
-class_name BlockContainerUi
+class_name FKBlockContainerUi
 ## Container for event blocks, comments, and groups in the FlowKit editor.
 ##
 ## Handles drag-and-drop reordering of blocks and accepts drops from
@@ -19,26 +19,102 @@ var current_drop_index: int = -1  ## Current calculated drop position
 
 # === Lifecycle ===
 
+func _enter_tree() -> void:
+	_toggle_subs(true)
+	pass
+	
+func _toggle_subs(on: bool):
+	if on and not _is_subbed:
+		child_entered_tree.connect(_on_child_entered_tree)
+		child_exiting_tree.connect(_on_child_exiting_tree)
+		
+	elif not on and _is_subbed:
+		child_entered_tree.disconnect(_on_child_entered_tree)
+		child_exiting_tree.disconnect(_on_child_exiting_tree)
+		
+	_is_subbed = on
+
+var _is_subbed := false
+
+func _on_child_entered_tree(child: Node):
+	if child is not FKUnitUi:
+		return
+	var ui := child as FKUnitUi
+	_update_lookup_registration(ui, true)
+	_toggle_sub_for(ui, true)
+	
+func _on_child_exiting_tree(child: Node):
+	if child is not FKUnitUi:
+		return
+	var ui := child as FKUnitUi
+	_update_lookup_registration(ui, false)
+	_toggle_sub_for(ui, false)
+
+
+	
+
 func _ready() -> void:
 	pass
 
+func _update_lookup_registration(ui: FKUnitUi, have_registered: bool):
+	if not is_instance_valid(ui) or ui.is_queued_for_deletion():
+		var error_message: = "[FKBlockContainerUi] Can't register " + ui.name + \
+		" into lookup. It's invalid or queued for deletion."
+		printerr(error_message)
+		return
+		
+	if have_registered:
+		_unit_lookup[ui] = ui.get_block()
+	elif _unit_lookup.has(ui):
+		_unit_lookup.erase(ui)
+		
+var _unit_lookup: Dictionary[FKUnitUi, FKUnit] = {}
 
+# We need this to keep our unit cache updated whenever needed.
+func _toggle_sub_for(ui: FKUnitUi, on: bool):
+	if on:
+		ui.block_changed.connect(_on_unit_ui_block_changed)
+	else:
+		ui.block_changed.disconnect(_on_unit_ui_block_changed)
+		
+func _on_unit_ui_block_changed(ui: FKUnitUi):
+	_update_lookup_registration(ui, true) 
+	# ^ Since we're listening for this unit ui, naturally we'll want to keep it registered
+			
+## Returns an array containing the FKUnits represented by the top-level FKUnitUis
+## parented to this container.
+var units: Array[FKUnit]:
+	get:
+		return _unit_lookup.values()
+
+## Returns an array of the top-level FKUnitUis parented to this container.
+var unit_uis: Array[FKUnitUi]:
+	get:
+		return _unit_lookup.keys()
+		
+## Removes all FKUnitUis this container is holding.
+func clear_unit_nodes():
+	for child in get_children():
+		if child is FKUnitUi:
+			remove_child(child)
+			child.queue_free()
+	
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_DRAG_END:
 		_hide_drop_indicator()
 
 # === Block Management ===
 
-func _get_visible_blocks() -> Array[Control]:
+func _get_visible_blocks() -> Array[FKUnitUi]:
 	"""Get all visible block children (excluding indicator and labels)."""
-	var blocks: Array[Control] = []
-	for child in get_children():
+	var blocks: Array[FKUnitUi] = []
+	for child in _unit_lookup.keys():
 		if DropIndicatorManager.is_indicator(child):
 			continue
 		# Skip invalid or deleted children
 		if not is_instance_valid(child) or child.is_queued_for_deletion():
 			continue
-		if child.visible and child.name != "EmptyLabel":
+		if child.visible and child is FKUnitUi:
 			blocks.append(child)
 	return blocks
 
@@ -112,19 +188,24 @@ func _can_drop_data(at_position: Vector2, data) -> bool:
 
 func _drop_data(at_position: Vector2, data) -> void:
 	"""Handle the drop operation."""
+	#print("[FKBlockContainerUi] In _drop_data")
 	_hide_drop_indicator()
 	
-	var node = _get_drag_node(data)
+	var node := _get_drag_node(data)
 	if node == null or not is_instance_valid(node):
+		printerr("[FKBlockContainerUi] _drop_data: drag node invalid")
 		return
 	
+	#print("[FKBlockContainerUi] Drag node: " + node.name)
 	var visible_blocks = _get_visible_blocks()
 	var target_visual_idx = _calculate_visual_drop_index(at_position, visible_blocks)
 	var is_from_different_parent = node.get_parent() != self
 	
 	if is_from_different_parent:
+		#print("[FKBlockContainerUi] Handling external drop")
 		_handle_external_drop(node, visible_blocks, target_visual_idx)
 	else:
+		#print("[FKBlockContainerUi] Handling internal reorder")
 		_handle_internal_reorder(node, visible_blocks, target_visual_idx)
 
 
@@ -170,6 +251,7 @@ func _handle_internal_reorder(node: Node, visible_blocks: Array, target_idx: int
 	
 	# No-op if same position
 	if target_idx == current_visual_idx or target_idx == current_visual_idx + 1:
+		#print("[FKBlockContainerUi] No op. Same pos")
 		return
 	
 	# Calculate actual child index
@@ -186,8 +268,20 @@ func _handle_internal_reorder(node: Node, visible_blocks: Array, target_idx: int
 		target_child_idx -= 1
 	
 	before_block_moved.emit()
+	#print("[FKBlockContainerUi] About to move block to index " + str(target_child_idx))
 	move_child(node, target_child_idx)
+	_refresh_unit_lookup()
+	#print("[FKBlockContainerUi] Done moving block. It is at index " + str(node.get_index()))
 	block_moved.emit()
+
+func _refresh_unit_lookup():
+	## This is so that our properties for exposing the units and their uis
+	## have things in the correct order. This makes sure that reorders stick.
+	_unit_lookup.clear()
+	for elem in get_children():
+		if elem is FKUnitUi:
+			var ui := elem as FKUnitUi
+			_unit_lookup[ui] = ui.get_block()
 
 # === Input Handling ===
 
@@ -210,3 +304,6 @@ func _gui_input(event: InputEvent) -> void:
 		
 		if not clicked_on_child:
 			empty_area_clicked.emit()
+
+func _exit_tree() -> void:
+	_toggle_subs(false)

--- a/addons/flowkit/ui/main_editor.gd
+++ b/addons/flowkit/ui/main_editor.gd
@@ -15,7 +15,7 @@ const GROUP_SCENE = preload("res://addons/flowkit/ui/workspace/group_ui.tscn")
 
 # UI References
 @export var scroll_container: ScrollContainer
-@export var blocks_container: BlockContainerUi
+@export var blocks_container: FKBlockContainerUi
 @export var empty_label: Label
 @export var add_event_btn: Button
 @export var menu_bar: FKMenuBar
@@ -36,7 +36,7 @@ const DRAG_SPACER_HEIGHT := 50  # Height of temporary drop zone
 var pending_block_type: String = ""  # "event", "condition", "action", "event_replace", "event_in_group", etc.
 var pending_node_path: String = ""
 var pending_id: String = ""
-var pending_target_row: Control = null  # The event row being modified
+var pending_target_row: FKUnitUi = null  # The event row being modified
 var pending_target_item: FKUnitUi = null  # The specific condition/action item being edited
 var pending_target_group: Control = null  # The group to add content to (for event_in_group workflow)
 var pending_target_branch: FKBranchUnitUi = null  # The branch item for branch sub-action workflows
@@ -304,18 +304,9 @@ func _paste_group() -> void:
 	
 # === Undo/Redo System ===
 func _push_undo_state() -> void:
-	var units := _get_units_from_block_nodes()
+	var units := blocks_container.units
 	undo_manager.push_state(units)
 
-func _get_units_from_block_nodes() -> Array[FKUnit]:
-	var units: Array[FKUnit] = []
-	for ui in _get_block_nodes():
-		if ui and is_instance_valid(ui) and ui.has_block():
-			var unit := ui.get_block()
-			units.append(unit)
-			
-	return units
-	
 func _clear_undo_history() -> void:
 	"""Clear undo/redo history (called when switching scenes)."""
 	undo_manager.clear()
@@ -325,7 +316,7 @@ func _undo() -> void:
 		return
 	_is_in_undo_redo = true
 	#print("[FKMainEditor]: Capturing units for undo")
-	var current_units := _capture_current_units()
+	var current_units := blocks_container.units
 	#print("[FKMainEditor]: Fetching prev state from undo manager")
 	var prev_state := undo_manager.undo(current_units)
 	var restored_units := ArrayUtils.get_fk_units_in(prev_state)
@@ -342,21 +333,12 @@ func _undo() -> void:
 	_save_sheet()
 	print("[FlowKit] Undo performed")
 var _is_in_undo_redo := false
-
-func _capture_current_units() -> Array[FKUnit]:
-	var units: Array[FKUnit] = []
-	for ui in _get_block_nodes():
-		if ui and is_instance_valid(ui):
-			var block := ui.get_block()
-			if block:
-				units.append(block)
-	return units
 	
 func _redo() -> void:
 	if not undo_manager.can_redo() or _is_in_undo_redo:
 		return
 	_is_in_undo_redo = true
-	var current_units := _capture_current_units()
+	var current_units := blocks_container.units
 	var restored_units := ArrayUtils.get_fk_units_in(undo_manager.redo(current_units))
 
 	_restore_unit_uis(restored_units)
@@ -365,7 +347,7 @@ func _redo() -> void:
 	print("[FlowKit] Redo performed")
 
 func _restore_unit_uis(units: Array[FKUnit]) -> void:
-	_clear_all_blocks()
+	blocks_container.clear_unit_nodes()
 
 	for unit in units:
 		#print("[FKMainEditor]: Current unit in _restore_unit_uis:")
@@ -554,7 +536,7 @@ func _process(delta: float) -> void:
 	if not scene_root:
 		if current_scene_uid != 0:
 			current_scene_uid = 0
-			_clear_all_blocks()
+			blocks_container.clear_block_nodes()
 			_clear_undo_history()
 			_show_empty_state()
 		return
@@ -563,7 +545,7 @@ func _process(delta: float) -> void:
 	if scene_path == "":
 		if current_scene_uid != 0:
 			current_scene_uid = 0
-			_clear_all_blocks()
+			blocks_container.clear_block_nodes()
 			_clear_undo_history()
 			_show_empty_state()
 		return
@@ -572,38 +554,9 @@ func _process(delta: float) -> void:
 	if scene_uid != current_scene_uid:
 		current_scene_uid = scene_uid
 		_clear_undo_history()
-		_load_scene_sheet()
+		_refresh_ui()
 
 # === Block Management ===
-
-func _get_block_nodes() -> Array[FKUnitUi]:
-	"""Get all block nodes (excluding empty label and nodes queued for deletion)."""
-	var blocks: Array[FKUnitUi] = []
-	
-	for child in blocks_container.get_children():
-		if !is_instance_valid(child):
-			#print("[FKMainEditor _get_block_nodes]: skipping " + child.name + " since it is not valid.")
-			continue
-			
-		if child.is_queued_for_deletion():
-			#print("[FKMainEditor _get_block_nodes]: skipping " + child.name + " since it is queued for deletion.")
-			continue
-			
-		if child is FKUnitUi:
-			#print("[FKMainEditor]: Registering " + child.name + " as a block Ui")
-			blocks.append(child)
-		else:
-			#print("[FKMainEditor]: NOT registering " + child.name + " as a block Ui")
-			pass
-	
-	return blocks
-
-func _clear_all_blocks() -> void:
-	"""Remove all blocks from the container."""
-	for child in blocks_container.get_children():
-		if child != empty_label:
-			blocks_container.remove_child(child)
-			child.queue_free()
 
 func _show_empty_blocks_state() -> void:
 	"""Show state when scene is loaded but has no blocks."""
@@ -615,26 +568,11 @@ func _show_content_state() -> void:
 	empty_label.visible = false
 	add_event_btn.visible = true
 
+func _get_block_nodes() -> Array[FKUnitUi]:
+	return blocks_container.unit_uis
+	
 # === File Operations ===
-
-func _load_scene_sheet() -> void:
-	"""Load event sheet for current scene."""
-	_clear_all_blocks()
-	if sheet_io == null:
-		printerr("[FKMainEditor]: Sheet io is null for some reason")
-	var sheet_path = sheet_io.get_sheet_path(current_scene_uid)
-	if sheet_path == "" or not FileAccess.file_exists(sheet_path):
-		_show_empty_blocks_state()
-		return
 	
-	var sheet := ResourceLoader.load(sheet_path)
-	if not (sheet is FKEventSheet):
-		_show_empty_blocks_state()
-		return
-	
-	_populate_from_sheet(sheet)
-	_show_content_state()
-
 func _populate_from_sheet(sheet: FKEventSheet) -> void:
 	"""Create event rows and comments from event sheet data (GDevelop-style)."""
 	# If we have item_order, use it to restore the correct order
@@ -645,12 +583,15 @@ func _populate_from_sheet(sheet: FKEventSheet) -> void:
 			
 			if item_type == "event" and item_index < sheet.events.size():
 				var event_row = _create_event_row(sheet.events[item_index])
-				blocks_container.add_child(event_row)
+				#print("[FKMainEditor] Adding event row child to block container")
+				blocks_container.add_child(event_row, false, 0)
 			elif item_type == "comment" and item_index < sheet.comments.size():
 				var comment = _create_comment_ui(sheet.comments[item_index])
+				#print("[FKMainEditor] Adding comment child to block container")
 				blocks_container.add_child(comment)
 			elif item_type == "group" and item_index < sheet.groups.size():
 				var group = _create_group_block(sheet.groups[item_index])
+				#print("[FKMainEditor] Adding group child to block container")
 				blocks_container.add_child(group)
 	else:
 		# Fallback: load events only (backwards compatibility)
@@ -658,102 +599,61 @@ func _populate_from_sheet(sheet: FKEventSheet) -> void:
 			var event_row := _create_event_row(event_data)
 			blocks_container.add_child(event_row)
 
-func _save_sheet() -> void:
+func _save_and_reload_sheet() -> void:
+	"""Save sheet and refresh UI to ensure visual/data sync (for drag-drop operations)."""
+	var saved := _save_sheet()
+	_refresh_ui(saved)
+	
+## Saves the sheet to disk before returning it.
+## If saving fails, this returns null.
+func _save_sheet() -> FKEventSheet:
 	var is_scene_open := current_scene_uid != 0
 	if not is_scene_open or _is_in_undo_redo:
-		push_warning("No scene open to save event sheet.")
+		push_warning("[FKMainEditor] No scene open to save event sheet.")
 		return
 
-	var sheet := _generate_sheet_from_blocks()
-	#print("[FKMainEditor]: Generated sheet from blocks for _save_sheet. Its arr sizes:")
-	#print("Comments: " + str(sheet.comments.size()))
-	#print("Events: " + str(sheet.events.size()))
-	#print("Groups: " + str(sheet.groups.size()))
-	#print("Standalone conditions: " + str(sheet.standalone_conditions.size()))
+	var units := blocks_container.units
+	#print("[FKMainEditor] Units found to save in _save_sheet:")
+	#for elem in units:
+		#print(elem.get_class())
+		
+	var sheet := FKEventSheet.from_copies_of(units)
 	var err := sheet_io.save_sheet(current_scene_uid, sheet)
-
+	var result: FKEventSheet = null
 	if err == OK:
 		print("[FKMainEditor] ✓ Event sheet saved")
+		result = sheet
 	else:
 		push_error("[FKMainEditor] Failed to save event sheet: ", err)
 	
-
-func _save_and_reload_sheet() -> void:
-	"""Save sheet and reload UI to ensure visual/data sync (for drag-drop operations)."""
-	_save_sheet()
-	_load_scene_sheet()
-
-func _generate_sheet_from_blocks() -> FKEventSheet:
-	"""Build event sheet from event rows, comments, and groups (GDevelop-style)."""
-	#print("[FKMainEditor]: Generating sheet from blocks")
-	var sheet = FKEventSheet.new()
-	var events: Array[FKEventBlock] = []
-	var comments: Array[FKComment] = []
-	var groups: Array[FKGroup] = []
-	var item_order: Array[Dictionary] = []
-	var standalone_conditions: Array[FKConditionUnit] = []
+	return result
 	
-	var block_nodes := _get_block_nodes()
-	#print("[FKMainEditor]: Amount of block nodes to work with: " + str(block_nodes.size()))
-	for block_ui in block_nodes:
-		# Skip invalid or deleted blocks
-		if not is_instance_valid(block_ui):
-			print("[FKMainEditor _generate_sheet_from_blocks]: skipping " + block_ui.name + \
-			" because it is not valid")
-			continue
-			
-		if block_ui.is_queued_for_deletion():
-			print("[FKMainEditor _generate_sheet_from_blocks]: skipping " + block_ui.name + \
-			" because it is queued for deletion")
-			continue
-		
-		var data := block_ui.get_block()
-		if not data:
-			print("[FKMainEditor]: " + block_ui.name + " has no block assigned, so we'll skip it")
-			continue
-		
-		var order_to_append: Dictionary = \
-		{
-			"type": data.block_type,
-			"index": 0
-		}
-		if data is FKEventBlock:
-			#print("[FKMainEditor]: saving FKEventBlock")
-			var event_copy = sheet_io.copy_event_block(data)
-			order_to_append["index"] = events.size()
-			events.append(event_copy)
-		
-		elif data is FKComment:
-			#print("[FKMainEditor]: saving FKComment")
-			var comment_copy: FKComment = data.duplicate_block()
-			order_to_append["index"] = comments.size()
-			comments.append(comment_copy)
-		
-		elif data is FKGroup:
-			#print("[FKMainEditor]: saving FKGroup")
-			var group_copy = sheet_io.copy_group_block(data)
-			order_to_append["index"] = groups.size()
-			groups.append(group_copy)
-		else:
-			print("[FKMainEditor]: Found strange " + data.block_type)
-			pass
-			
-		item_order.append(order_to_append)
+# Refreshes the Event Sheet Ui based on the sheet passed. If none is passed, 
+# this goes for the sheet tied to the current scene uid.
+func _refresh_ui(sheet: FKEventSheet = null):
+	if not sheet:
+		# Why this fallback? We want other parts of this script to be able to
+		# refresh the ui without having to look for the sheet first.
+		sheet = sheet_io.load_sheet(current_scene_uid)
+	_refresh_sheet_ui(sheet)
 	
-	sheet.events = events
-	sheet.comments = comments
-	sheet.groups = groups
-	sheet.item_order = item_order
-	sheet.standalone_conditions = standalone_conditions
-	return sheet
-
+func _refresh_sheet_ui(sheet: FKEventSheet):
+	blocks_container.clear_unit_nodes()
+	
+	if not sheet:
+		_show_empty_blocks_state()
+		return
+		
+	_populate_from_sheet(sheet)
+	_show_content_state()
+	
 func _new_sheet() -> void:
 	"""Create new empty sheet."""
 	if current_scene_uid == 0:
-		push_warning("No scene open to create event sheet.")
+		push_warning("No scene open to create event sheet for.")
 		return
 	
-	_clear_all_blocks()
+	blocks_container.clear_block_nodes()
 	_show_content_state()
 
 # === Event Row Creation ===
@@ -1411,7 +1311,7 @@ func _update_event_inputs(expressions: Dictionary) -> void:
 	_push_undo_state()
 	
 	if pending_target_row:
-		var data: FKEventRowUi = pending_target_row.get_block()
+		var data: FKUnit = pending_target_row.get_block()
 		if data:
 			data.inputs = expressions
 			pending_target_row.update_display()
@@ -1471,11 +1371,15 @@ func _replace_event(expressions: Dictionary) -> void:
 	# Remove old row and insert new one at same position
 	if old_parent:
 		old_parent.remove_child(pending_target_row)
+		
 	pending_target_row.queue_free()
 	
 	# Add to the same parent (blocks_container or children_container within group)
 	if old_parent:
-		old_parent.add_child(new_row)
+		if old_parent is FKBlockContainerUi and new_row is FKUnitUi:
+			old_parent.add_child(new_row)
+		else:
+			old_parent.add_child(new_row)
 		old_parent.move_child(new_row, old_index)
 	else:
 		# Fallback if no parent found

--- a/addons/flowkit/ui/main_editor.gd
+++ b/addons/flowkit/ui/main_editor.gd
@@ -8,11 +8,6 @@ var registry: FKRegistry
 var generator
 var current_scene_uid: int = 0
 
-# Scene preloads - GDevelop-style event rows
-const EVENT_ROW_SCENE = preload("res://addons/flowkit/ui/workspace/event_row_ui.tscn")
-const COMMENT_SCENE = preload("res://addons/flowkit/ui/workspace/comment_ui.tscn")
-const GROUP_SCENE = preload("res://addons/flowkit/ui/workspace/group_ui.tscn")
-
 # UI References
 @export var scroll_container: ScrollContainer
 @export var blocks_container: FKBlockContainerUi
@@ -49,10 +44,13 @@ var clipboard := FKClipboardManager.new()
 var input_manager: FKMainEditorInputHandler = FKMainEditorInputHandler.new()
 var sheet_io : FKSheetIO = FKSheetIO.new()
 var serializer := FKSerializationManager.new()
+var unit_ui_factory: FKUnitUiFactory
 
 func _enter_tree() -> void:
+	unit_ui_factory = FKUnitUiFactory.new(sheet_io)
 	input_manager.initialize(self)
 	_toggle_subs(true)
+	
 
 func _toggle_subs(on: bool):
 	if on and not _is_subbed:
@@ -98,6 +96,9 @@ func set_editor_interface(interface: EditorInterface) -> void:
 
 func set_registry(reg: FKRegistry) -> void:
 	registry = reg
+	if not unit_ui_factory:
+		unit_ui_factory = FKUnitUiFactory.new(sheet_io)
+	unit_ui_factory.registry = reg
 	# Pass to modals (deferred in case they're not ready yet)
 	if select_event_modal:
 		select_event_modal.set_registry(reg)
@@ -170,7 +171,7 @@ func _paste_events() -> void:
 
 	var first_row = null
 	for ev in new_events:
-		var row = _create_event_row(ev)
+		var row := _create_unit_ui(ev)
 		blocks_container.add_child(row)
 		blocks_container.move_child(row, insert_idx)
 		insert_idx += 1
@@ -296,7 +297,8 @@ func _paste_group() -> void:
 		return
 
 	# Otherwise paste at root level
-	var group_node := _create_group_block(new_group)
+	var group_node := unit_ui_factory.unit_ui_from(new_group)
+	_wire_signals(group_node)
 	blocks_container.add_child(group_node)
 
 	_save_sheet()
@@ -352,7 +354,7 @@ func _restore_unit_uis(units: Array[FKUnit]) -> void:
 	for unit in units:
 		#print("[FKMainEditor]: Current unit in _restore_unit_uis:")
 		#print(unit.get_class() + ": " + str(unit))
-		var node := _create_block_node(unit)
+		var node := _create_unit_ui(unit)
 		blocks_container.add_child(node)
 
 	if units.size() > 0:
@@ -367,16 +369,10 @@ func _restore_unit_uis(units: Array[FKUnit]) -> void:
 		
 
 
-func _create_block_node(block_resource: FKUnit) -> FKUnitUi:
-	var result: FKUnitUi = null
-	
-	if block_resource is FKComment:
-		result = _create_comment_ui(block_resource)
-	elif block_resource is FKGroup:
-		result = _create_group_block(block_resource)
-	else:
-		result = _create_event_row(block_resource)
-		
+func _create_unit_ui(unit: FKUnit) -> FKUnitUi:
+	var result: FKUnitUi = unit_ui_factory.unit_ui_from(unit)
+	if result:
+		_wire_signals(result)
 	return result
 
 func _delete_selected_row() -> void:
@@ -574,31 +570,28 @@ func _get_block_nodes() -> Array[FKUnitUi]:
 # === File Operations ===
 	
 func _populate_from_sheet(sheet: FKEventSheet) -> void:
-	"""Create event rows and comments from event sheet data (GDevelop-style)."""
-	# If we have item_order, use it to restore the correct order
-	if sheet.item_order.size() > 0:
-		for item in sheet.item_order:
-			var item_type = item.get("type", "")
-			var item_index: int = item.get("index", 0)
-			
-			if item_type == "event" and item_index < sheet.events.size():
-				var event_row = _create_event_row(sheet.events[item_index])
-				#print("[FKMainEditor] Adding event row child to block container")
-				blocks_container.add_child(event_row, false, 0)
-			elif item_type == "comment" and item_index < sheet.comments.size():
-				var comment = _create_comment_ui(sheet.comments[item_index])
-				#print("[FKMainEditor] Adding comment child to block container")
-				blocks_container.add_child(comment)
-			elif item_type == "group" and item_index < sheet.groups.size():
-				var group = _create_group_block(sheet.groups[item_index])
-				#print("[FKMainEditor] Adding group child to block container")
-				blocks_container.add_child(group)
-	else:
-		# Fallback: load events only (backwards compatibility)
-		for event_data in sheet.events:
-			var event_row := _create_event_row(event_data)
-			blocks_container.add_child(event_row)
+	blocks_container.clear_unit_nodes()
 
+	# Use the sheet’s own ordered_items list
+	for unit in sheet.ordered_items:
+		var ui := unit_ui_factory.unit_ui_from(unit)
+		_wire_signals(ui)
+		blocks_container.add_child(ui)
+
+	if sheet.ordered_items.is_empty():
+		_show_empty_blocks_state()
+	else:
+		_show_content_state()
+
+func _wire_signals(unit: FKUnitUi):
+	if unit is FKCommentUi:
+		_connect_comment_signals(unit)
+	elif unit is FKGroupUi:
+		_connect_group_signals(unit)
+	else:
+		_connect_event_row_signals(unit)
+		
+	
 func _save_and_reload_sheet() -> void:
 	"""Save sheet and refresh UI to ensure visual/data sync (for drag-drop operations)."""
 	var saved := _save_sheet()
@@ -617,7 +610,7 @@ func _save_sheet() -> FKEventSheet:
 	#for elem in units:
 		#print(elem.get_class())
 		
-	var sheet := FKEventSheet.from_copies_of(units)
+	var sheet := FKEventSheet.from_units(units)
 	var err := sheet_io.save_sheet(current_scene_uid, sheet)
 	var result: FKEventSheet = null
 	if err == OK:
@@ -658,27 +651,6 @@ func _new_sheet() -> void:
 
 # === Event Row Creation ===
 
-func _create_event_row(data: FKEventBlock) -> FKEventRowUi:
-	"""Create event row node from data (GDevelop-style)."""
-	#print("[FKMainEditor] Creating event row node")
-	var row: FKEventRowUi = EVENT_ROW_SCENE.instantiate()
-	var copy := sheet_io.copy_event_block(data)
-	
-	row.legitimize(copy, registry)
-	_connect_event_row_signals(row)
-	return row
-
-func _create_comment_ui(data: FKComment) -> FKCommentUi:
-	"""Create comment block node from data."""
-	#print("[FKMainEditor]: Creating comment block node")
-	var comment: FKCommentUi = COMMENT_SCENE.instantiate()
-	var copy := FKComment.new()
-	copy.text = data.text
-	
-	comment.legitimize(copy, registry)
-	_connect_comment_signals(comment)
-	return comment
-
 func _connect_comment_signals(comment: FKCommentUi) -> void:
 	comment.selected.connect(_on_comment_selected)
 	comment.delete_requested.connect(_on_comment_delete.bind(comment))
@@ -688,16 +660,7 @@ func _connect_comment_signals(comment: FKCommentUi) -> void:
 	comment.insert_event_above_requested.connect(_on_comment_insert_event_above.bind(comment))
 	comment.insert_event_below_requested.connect(_on_comment_insert_event_below.bind(comment))
 
-func _create_group_block(data: FKGroup) -> FKGroupUi:
-	"""Create group block node from data."""
-	#print("[FKMainEditor]: Creating group block node")
-	var group: FKGroupUi = GROUP_SCENE.instantiate()
-	var copy := data.copy_deep()
-	copy.normalize_children()
-	#group.call_deferred("legitimize", copy, registry)
-	group.legitimize(copy, registry)
-	_connect_group_signals(group)
-	return group
+
 
 func _connect_group_signals(group: FKGroupUi) -> void:
 	group.selected.connect(_on_group_selected)
@@ -788,7 +751,7 @@ func _on_add_group_button_pressed() -> void:
 	data.color = Color(0.25, 0.22, 0.35, 1.0)
 	data.children = []
 	
-	var group := _create_group_block(data)
+	var group := _create_unit_ui(data)
 	blocks_container.add_child(group)
 	
 	_show_content_state()
@@ -935,7 +898,7 @@ func _on_add_comment_button_pressed() -> void:
 	var data := FKComment.new()
 	data.text = ""
 	
-	var comment := _create_comment_ui(data)
+	var comment := _create_unit_ui(data)
 	blocks_container.add_child(comment)
 	
 	_show_content_state()
@@ -1006,7 +969,7 @@ func _insert_comment_relative_to(target_block: Node, offset: int) -> void:
 	var data := FKComment.new()
 	data.text = ""
 	
-	var comment := _create_comment_ui(data)
+	var comment := _create_unit_ui(data)
 	blocks_container.add_child(comment)
 	
 	# Calculate insert position
@@ -1207,7 +1170,7 @@ func _finalize_event_creation(inputs: Dictionary) -> void:
 	data.conditions = [] as Array[FKConditionUnit]
 	data.actions = [] as Array[FKActionUnit]
 	
-	var row := _create_event_row(data)
+	var row := _create_unit_ui(data)
 	
 	if pending_target_row:
 		var insert_idx := pending_target_row.get_index() + 1
@@ -1232,7 +1195,7 @@ func _finalize_event_above_target(inputs: Dictionary) -> void:
 	data.conditions = [] as Array[FKConditionUnit]
 	data.actions = [] as Array[FKActionUnit]
 	
-	var row := _create_event_row(data)
+	var row := _create_unit_ui(data)
 	
 	if pending_target_row:
 		var insert_idx := pending_target_row.get_index()  # Insert at same position (above)
@@ -1366,7 +1329,7 @@ func _replace_event(expressions: Dictionary) -> void:
 	new_data.actions = old_data.actions if old_data else ([] as Array[FKActionUnit])
 	
 	# Create new row
-	var new_row := _create_event_row(new_data)
+	var new_row := _create_unit_ui(new_data)
 	
 	# Remove old row and insert new one at same position
 	if old_parent:
@@ -1784,9 +1747,9 @@ func _finalize_branch_action_creation(inputs: Dictionary) -> void:
 	if pending_target_branch and pending_target_branch.has_method("add_branch_action"):
 		pending_target_branch.add_branch_action(data)
 	elif pending_target_branch is FKBranchUnitUi:
-		print("[FKMainEditor]: Pending target branch has no add_branch_action method, but it is a FKBranchUnitUi ")
+		print("[FKMainEditor]: Pending target branch has no add_branch_action method, " +\
+		"but it is a FKBranchUnitUi.")
 		
-
 	_show_content_state()
 	_reset_workflow()
 	_save_sheet()
@@ -1948,6 +1911,7 @@ func _on_action_edit_requested(action_item: FKActionUnitUi, bound_row) -> void:
 func _on_condition_dropped(source_row: FKEventRowUi, condition_data: FKConditionUnit, 
 target_row: FKEventRowUi) -> void:
 	"""Handle condition dropped from one event row to another."""
+	print("[FKMainEditor] _on_condition_dropped")
 	if not source_row or not target_row or not condition_data:
 		return
 	
@@ -1962,13 +1926,7 @@ target_row: FKEventRowUi) -> void:
 	# Add to target
 	var target_data := target_row.get_block()
 	if target_data:
-		# Create a copy of the condition data
-		var cond_copy := FKConditionUnit.new()
-		cond_copy.condition_id = condition_data.condition_id
-		cond_copy.target_node = condition_data.target_node
-		cond_copy.inputs = condition_data.inputs.duplicate()
-		cond_copy.negated = condition_data.negated
-		cond_copy.actions = [] as Array[FKActionUnit]
+		var cond_copy := condition_data.duplicate_block()
 		
 		target_data.conditions.append(cond_copy)
 		target_row.update_display()
@@ -1977,6 +1935,7 @@ target_row: FKEventRowUi) -> void:
 
 func _on_action_dropped(source_row: FKEventRowUi, action_data: FKActionUnit, target_row: FKUnitUi) -> void:
 	"""Handle action dropped from one event row to another."""
+	print("[FKMainEditor] _on_action_dropped")
 	if not source_row or not target_row or not action_data:
 		return
 	


### PR DESCRIPTION
# What This PR Does
## Moves responsibilities from FKMainEditor → FKEventSheet
- Determining the correct ordering of FKUnits for UI refresh
- FKEventSheet now exposes an ordered list of units, so FKMainEditor no longer reconstructs order manually in _populate_from_sheet().
- Writing FKUnits into the sheet
- Generating new FKEventSheet instances from a list of FKUnits
This consolidates all sheet‑structure logic into the sheet itself, where it belongs.

## Moves responsibilities from FKMainEditor → FKBlockContainerUi
- Gathering FKUnitUis and their represented FKUnits
- FKBlockContainerUi now maintains a lookup table and exposes units / unit_uis properties, so clients no longer need to manually iterate children or reconstruct ordering.
This makes the container the authoritative source for UI‑side block order and lookup.

## Introduces a new class: FKUnitUiFactory
- Responsible for creating FKUnitUi nodes from FKUnits
- Currently supports EventRows, Comments, and Groups
- (Condition/action UIs will be added later once structural issues are resolved)
This removes UI instantiation logic from FKMainEditor and centralizes it in a dedicated factory.

## Small Improvements
- FKUnitUi’s before_block_changed and block_changed signals now explicitly specify that the passed node is an FKUnitUi.
- Added optional debug print logs to aid troubleshooting.

## Bugfix(es)
- Fixed a regression that prevented comment reordering from persisting.
