### PR TITLE
Refactor: Main Editor Modals as Export Fields | Signal Connections Moved to Code

### DIFF
--- a/addons/flowkit/ui/main_editor.gd
+++ b/addons/flowkit/ui/main_editor.gd
@@ -57,14 +57,13 @@ func _enter_tree() -> void:
 	
 func _toggle_subs(on: bool):
 	if on and not _is_subbed:
-		# For autosave and undo state on drag-and-drop reorder
+		# For undo state on drag-and-drop reorder
 		blocks_container.before_block_moved.connect(_push_undo_state)
 		select_node_modal.node_selected.connect(_on_node_selected)
 		select_event_modal.event_selected.connect(_on_event_selected)
 		select_action_modal.action_selected.connect(_on_action_selected)
 		select_condition_modal.condition_selected.connect(_on_condition_selected)
 		expression_modal.expressions_confirmed.connect(_on_expressions_confirmed)
-		#blocks_container.block_moved.connect(_on_auto_saver_saved)
 	elif not on and _is_subbed:
 		blocks_container.before_block_moved.disconnect(_push_undo_state)
 		select_node_modal.node_selected.disconnect(_on_node_selected)
@@ -72,7 +71,6 @@ func _toggle_subs(on: bool):
 		select_action_modal.action_selected.disconnect(_on_action_selected)
 		select_condition_modal.condition_selected.disconnect(_on_condition_selected)
 		expression_modal.expressions_confirmed.disconnect(_on_expressions_confirmed)
-		#blocks_container.block_moved.disconnect(_on_auto_saver_saved)
 	
 	_is_subbed = on
 

--- a/addons/flowkit/ui/main_editor.gd
+++ b/addons/flowkit/ui/main_editor.gd
@@ -23,11 +23,11 @@ var drag_spacer_bottom: Control = null  # Temporary spacer at bottom during drag
 const DRAG_SPACER_HEIGHT := 50  # Height of temporary drop zone
 
 # Modals
-@onready var select_node_modal: FKSelectNodeModal = $SelectNodeModal
-@onready var select_event_modal: FKSelectEventModal = $SelectEventModal
-@onready var select_condition_modal: FKSelectConditionModal = $SelectConditionModal
-@onready var select_action_modal: FKSelectActionModal = $SelectActionModal
-@onready var expression_modal: FKExpressionEditorModal = $ExpressionModal
+@export var select_node_modal: FKSelectNodeModal
+@export var select_event_modal: FKSelectEventModal
+@export var select_condition_modal: FKSelectConditionModal
+@export var select_action_modal: FKSelectActionModal
+@export var expression_modal: FKExpressionEditorModal
 
 # Workflow state
 var pending_block_type: String = ""  # "event", "condition", "action", "event_replace", "event_in_group", etc.
@@ -103,12 +103,16 @@ func set_registry(reg: FKRegistry) -> void:
 		unit_ui_factory = FKUnitUiFactory.new(sheet_io)
 	unit_ui_factory.registry = reg
 	# Pass to modals (deferred in case they're not ready yet)
+	if select_node_modal:
+		select_node_modal.set_registry(reg)
 	if select_event_modal:
 		select_event_modal.set_registry(reg)
 	if select_condition_modal:
 		select_condition_modal.set_registry(reg)
 	if select_action_modal:
 		select_action_modal.set_registry(reg)
+	if expression_modal:
+		expression_modal.set_registry(reg)
 
 func set_generator(gen) -> void:
 	generator = gen

--- a/addons/flowkit/ui/main_editor.gd
+++ b/addons/flowkit/ui/main_editor.gd
@@ -59,9 +59,19 @@ func _toggle_subs(on: bool):
 	if on and not _is_subbed:
 		# For autosave and undo state on drag-and-drop reorder
 		blocks_container.before_block_moved.connect(_push_undo_state)
+		select_node_modal.node_selected.connect(_on_node_selected)
+		select_event_modal.event_selected.connect(_on_event_selected)
+		select_action_modal.action_selected.connect(_on_action_selected)
+		select_condition_modal.condition_selected.connect(_on_condition_selected)
+		expression_modal.expressions_confirmed.connect(_on_expressions_confirmed)
 		#blocks_container.block_moved.connect(_on_auto_saver_saved)
 	elif not on and _is_subbed:
 		blocks_container.before_block_moved.disconnect(_push_undo_state)
+		select_node_modal.node_selected.disconnect(_on_node_selected)
+		select_event_modal.event_selected.disconnect(_on_event_selected)
+		select_action_modal.action_selected.disconnect(_on_action_selected)
+		select_condition_modal.condition_selected.disconnect(_on_condition_selected)
+		expression_modal.expressions_confirmed.disconnect(_on_expressions_confirmed)
 		#blocks_container.block_moved.disconnect(_on_auto_saver_saved)
 	
 	_is_subbed = on

--- a/addons/flowkit/ui/main_editor.tscn
+++ b/addons/flowkit/ui/main_editor.tscn
@@ -191,8 +191,3 @@ visible = false
 [connection signal="pressed" from="OuterVBox/TopMargin/TopBar/AddCommentButton" to="." method="_on_add_comment_button_pressed"]
 [connection signal="pressed" from="OuterVBox/TopMargin/TopBar/AddGroupButton" to="." method="_on_add_group_button_pressed"]
 [connection signal="pressed" from="OuterVBox/BottomMargin/ButtonContainer/AddEventButton" to="." method="_on_add_event_button_pressed"]
-[connection signal="node_selected" from="SelectNodeModal" to="." method="_on_node_selected"]
-[connection signal="event_selected" from="SelectEventModal" to="." method="_on_event_selected"]
-[connection signal="action_selected" from="SelectActionModal" to="." method="_on_action_selected"]
-[connection signal="condition_selected" from="SelectConditionModal" to="." method="_on_condition_selected"]
-[connection signal="expressions_confirmed" from="ExpressionModal" to="." method="_on_expressions_confirmed"]

--- a/addons/flowkit/ui/main_editor.tscn
+++ b/addons/flowkit/ui/main_editor.tscn
@@ -24,7 +24,7 @@ corner_radius_top_right = 6
 corner_radius_bottom_right = 6
 corner_radius_bottom_left = 6
 
-[node name="Control" type="Control" unique_id=945005444 node_paths=PackedStringArray("scroll_container", "blocks_container", "empty_label", "add_event_btn", "menu_bar")]
+[node name="Control" type="Control" unique_id=945005444 node_paths=PackedStringArray("scroll_container", "blocks_container", "empty_label", "add_event_btn", "menu_bar", "select_node_modal", "select_event_modal", "select_condition_modal", "select_action_modal", "expression_modal")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -39,6 +39,11 @@ blocks_container = NodePath("OuterVBox/ScrollContainer/MarginContainer/BlocksCon
 empty_label = NodePath("OuterVBox/ScrollContainer/MarginContainer/BlocksContainer/EmptyLabel")
 add_event_btn = NodePath("OuterVBox/BottomMargin/ButtonContainer/AddEventButton")
 menu_bar = NodePath("OuterVBox/TopMargin/TopBar/MenuBar")
+select_node_modal = NodePath("SelectNodeModal")
+select_event_modal = NodePath("SelectEventModal")
+select_condition_modal = NodePath("SelectConditionModal")
+select_action_modal = NodePath("SelectActionModal")
+expression_modal = NodePath("ExpressionModal")
 
 [node name="Background" type="Panel" parent="." unique_id=1222721060]
 layout_mode = 1

--- a/addons/flowkit/ui/modals/expression_editor_modal.gd
+++ b/addons/flowkit/ui/modals/expression_editor_modal.gd
@@ -41,6 +41,11 @@ func set_editor_interface(interface: EditorInterface) -> void:
 	if is_node_ready():
 		call_deferred("_setup_node_tree")
 
+func set_registry(reg: FKRegistry):
+	registry = reg
+	
+var registry: FKRegistry
+
 func populate_inputs(node_path: String, action_id: String, inputs: Array, \
 current_values: Dictionary = {}) -> void:
 	selected_node_path = node_path

--- a/addons/flowkit/ui/modals/select_action_modal.gd
+++ b/addons/flowkit/ui/modals/select_action_modal.gd
@@ -16,6 +16,16 @@ var available_actions: Array = []
 var _all_items_cache: Array = []
 var _recent_items_manager: Variant = null
 
+func set_editor_interface(interface: EditorInterface) -> void:
+	editor_interface = interface
+	
+var editor_interface: EditorInterface
+
+func set_registry(reg: FKRegistry):
+	registry = reg
+	
+var registry: FKRegistry
+
 func _ready() -> void:
 	if search_box:
 		search_box.text_changed.connect(_on_search_text_changed)

--- a/addons/flowkit/ui/modals/select_condition_modal.gd
+++ b/addons/flowkit/ui/modals/select_condition_modal.gd
@@ -46,6 +46,16 @@ func _load_available_conditions() -> void:
 	_scan_directory_recursive(conditions_path)
 	print("Loaded ", available_conditions.size(), " conditions")
 
+func set_editor_interface(interface: EditorInterface) -> void:
+	editor_interface = interface
+		
+var editor_interface: EditorInterface
+
+func set_registry(reg: FKRegistry):
+	registry = reg
+	
+var registry: FKRegistry
+
 func _scan_directory_recursive(path: String) -> void:
 	"""Recursively scan directories for condition scripts."""
 	var dir: DirAccess = DirAccess.open(path)

--- a/addons/flowkit/ui/modals/select_event_modal.gd
+++ b/addons/flowkit/ui/modals/select_event_modal.gd
@@ -16,6 +16,16 @@ var available_events: Array = []
 var _all_items_cache: Array = []
 var _recent_items_manager: Variant = null
 
+func set_editor_interface(interface: EditorInterface) -> void:
+	editor_interface = interface
+
+var editor_interface: EditorInterface
+
+func set_registry(reg: FKRegistry):
+	registry = reg
+	
+var registry: FKRegistry
+
 func _ready() -> void:
 	if search_box:
 		search_box.text_changed.connect(_on_search_text_changed)

--- a/addons/flowkit/ui/modals/select_node_modal.gd
+++ b/addons/flowkit/ui/modals/select_node_modal.gd
@@ -66,6 +66,11 @@ func _scan_directory_recursive(path: String) -> void:
 func set_editor_interface(interface: EditorInterface):
 	editor_interface = interface
 
+func set_registry(reg: FKRegistry):
+	registry = reg
+	
+var registry: FKRegistry
+
 func populate_from_scene(scene_root: Node) -> void:
 	if not item_list:
 		return


### PR DESCRIPTION
# Summary
This PR updates FKMainEditor so that its modal references (SelectNode, SelectEvent, etc.) are defined as export fields instead of onready variables. It also moves all signal connections between these modals and FKMainEditor out of the Godot Editor and into GDScript.

# The Changes
- Converts modal references from onready → export for clearer dependency visibility.
- Removes editor‑configured signal connections.
- Replaces them with explicit GDScript connections during initialization.
- Ensures all modal → editor communication is now traceable in code.

# Why This Matters
- Improved Traceability: It's easier to track the flow of code when the signals are hooked up through GDScript instead of Godot's editor
- Better Encapsulation: The modal listeners (_on_node_selected, _on_event_selected, etc.) contain important logic that will eventually be extracted into dedicated modules. Moving the signal wiring like this is needed to pull that off.
- Reduced Scene Coupling: With less of the logic hidden in scene files, it's easier to avoid breaking stuff.
- Modularization: This PR is yet another step towards making FKMainEditor more maintainable and extendable.