### PR TITLE
Modal Window Implementation Polish (+Some Cleanup)

### DIFF
--- a/addons/flowkit/actions/Node/print_message.gd
+++ b/addons/flowkit/actions/Node/print_message.gd
@@ -19,7 +19,8 @@ func get_inputs() -> Array[FKActionInput]:
 static var _color_input: FKStringActionInput:
 	get:
 		return FKStringActionInput.new("Color",
-		"Decides what BBCode color the message is wrapped in. Default: white.")
+		"Decides what BBCode color the message is wrapped in. Default: white.",
+		"white")
 
 static var _message_input: FKStringActionInput:
 	get:

--- a/addons/flowkit/editor/Ui/modal_paths.gd
+++ b/addons/flowkit/editor/Ui/modal_paths.gd
@@ -1,0 +1,9 @@
+## A collection of static fields pertaining to the modals
+## the editor uses.
+class_name FKModalPaths
+
+const SELECT_NODE_MODAL := "res://addons/flowkit/ui/modals/select_node_modal.tscn"
+const SELECT_ACTION_MODAL := "res://addons/flowkit/ui/modals/select_action_modal.tscn"
+const EXPRESSION_EDITOR_MODAL := "res://addons/flowkit/ui/modals/expression_editor.tscn"
+const SELECT_CONDITION_MODAL := "res://addons/flowkit/ui/modals/select_condition_modal.tscn"
+const SELECT_EVENT_MODAL := "res://addons/flowkit/ui/modals/select_event_modal.tscn"

--- a/addons/flowkit/editor/Ui/modal_paths.gd.uid
+++ b/addons/flowkit/editor/Ui/modal_paths.gd.uid
@@ -1,0 +1,1 @@
+uid://d1qgy5iyafaev

--- a/addons/flowkit/editor/editor_globals.gd
+++ b/addons/flowkit/editor/editor_globals.gd
@@ -8,3 +8,5 @@ const ACTION_ITEM_SCENE := preload("res://addons/flowkit/ui/workspace/action_uni
 
 const BRANCH_ITEM_SCENE_PATH := "res://addons/flowkit/ui/workspace/branch_unit_ui.tscn"
 const BRANCH_ITEM_SCENE := preload(BRANCH_ITEM_SCENE_PATH)
+
+const PATH_TO_EVENTS_FOLDER := "res://addons/flowkit/events"

--- a/addons/flowkit/editor/modals/modal_window.gd
+++ b/addons/flowkit/editor/modals/modal_window.gd
@@ -7,10 +7,14 @@ func _enter_tree() -> void:
 	_ensure_export_fields_filled()
 	_apply_styling()
 	
-	# From here on, we only act when we're a legit instance.
-	if is_editor_preview:
+	if is_editor_preview or is_fully_legit:
 		return
 	_toggle_subs(true)
+
+var is_fully_legit: bool:
+	get:
+		return _is_fully_legit
+var _is_fully_legit := false
 
 func _ensure_export_fields_filled():
 	pass 
@@ -37,12 +41,13 @@ var _editor_interface: EditorInterface
 func legitimize():
 	if not is_editor_preview:
 		return
-	_is_editor_preview = false
+	_is_editor_preview = false # So the initialization process can begin
 	_enter_tree()
 	_ready()
+	_is_fully_legit = true # And now we're done!
 	
 func _exit_tree() -> void:
-	if is_editor_preview:
+	if !is_fully_legit:
 		return
 	_toggle_subs(false)
 

--- a/addons/flowkit/editor/modals/modal_window.gd
+++ b/addons/flowkit/editor/modals/modal_window.gd
@@ -1,0 +1,55 @@
+extends PopupPanel
+class_name FKModalWindow
+
+func _enter_tree() -> void:
+	# For designer-friendliness, we want some things to proc
+	# even in editor preview
+	_ensure_export_fields_filled()
+	_apply_styling()
+	
+	# From here on, we only act when we're a legit instance.
+	if is_editor_preview:
+		return
+	_toggle_subs(true)
+
+func _ensure_export_fields_filled():
+	pass 
+	
+func _apply_styling():
+	pass
+	
+var is_editor_preview: bool:
+	get:
+		return _is_editor_preview
+		
+var _is_editor_preview := true
+
+func _toggle_subs(on: bool):
+	pass # We expect subclasses to override this
+	
+var _is_subbed := false
+
+func set_editor_interface(interface: EditorInterface):
+	editor_interface = interface
+	
+var editor_interface: EditorInterface
+
+func legitimize():
+	if not is_editor_preview:
+		return
+	_is_editor_preview = false
+	_enter_tree()
+	_ready()
+	
+func _exit_tree() -> void:
+	if is_editor_preview:
+		return
+	_toggle_subs(false)
+
+func set_registry(reg: FKRegistry):
+	_registry = reg
+	
+var _registry: FKRegistry
+
+func _ready() -> void:
+	pass

--- a/addons/flowkit/editor/modals/modal_window.gd
+++ b/addons/flowkit/editor/modals/modal_window.gd
@@ -30,9 +30,9 @@ func _toggle_subs(on: bool):
 var _is_subbed := false
 
 func set_editor_interface(interface: EditorInterface):
-	editor_interface = interface
+	_editor_interface = interface
 	
-var editor_interface: EditorInterface
+var _editor_interface: EditorInterface
 
 func legitimize():
 	if not is_editor_preview:

--- a/addons/flowkit/editor/modals/modal_window.gd.uid
+++ b/addons/flowkit/editor/modals/modal_window.gd.uid
@@ -1,0 +1,1 @@
+uid://cqpj7q1e18k84

--- a/addons/flowkit/editor/styles/modal_desc_panel_style.tres
+++ b/addons/flowkit/editor/styles/modal_desc_panel_style.tres
@@ -1,0 +1,4 @@
+[gd_resource type="StyleBoxFlat" format=3 uid="uid://coc5tirv43fp"]
+
+[resource]
+bg_color = Color(0.2, 0.2, 0.2, 0.8)

--- a/addons/flowkit/flowkit.gd
+++ b/addons/flowkit/flowkit.gd
@@ -18,22 +18,20 @@ func _disable_plugin() -> void:
 
 func _enter_tree() -> void:
 	# Load UI
-	print("[FlowKit] About to load main editor scene")
 	var editor_scene: PackedScene = preload("res://addons/flowkit/ui/main_editor.tscn")
-	print("[FlowKit] Loaded main editor scene. About to instantiate main editor.")
 	editor = editor_scene.instantiate()
 	editor.legitimize()
-	print("[FlowKit] Instantiated main editor.")
 	
 	# Load registry
-	action_registry = preload("res://addons/flowkit/registry.gd").new()
+	action_registry = FKRegistry.new() # preload("res://addons/flowkit/registry.gd").new()
 	action_registry.load_providers()
 	
 	# Initialize generator
-	generator = preload("res://addons/flowkit/generator.gd").new(get_editor_interface())
+	var ed_interface := get_editor_interface()
+	generator = FKGenerator.new(ed_interface)
 
 	# Pass editor interface and registry to the editor UI
-	editor.set_editor_interface(get_editor_interface())
+	editor.set_editor_interface(ed_interface)
 	editor.set_registry(action_registry)
 	editor.set_generator(generator)
 
@@ -49,28 +47,24 @@ func _enter_tree() -> void:
 	)
 
 	# Add editor as main screen plugin
-	editor_main_screen = get_editor_interface().get_editor_main_screen()
-	print("[FlowKit] About to parent editor to main screen.")
+	editor_main_screen = ed_interface.get_editor_main_screen()
 	editor_main_screen.add_child(editor)
-	print("[FlowKit] Added main editor to main screen. About to legitimize main editor.")
 	
-	
-	print("[FlowKit] Legitimized main editor")
 	# Hide by default until user clicks the FlowKit button
 	_make_visible(false)
 	
 	# Create and add custom inspector
-	inspector_plugin = preload("res://addons/flowkit/ui/inspector/flowkit_inspector_plugin.gd").new()
+	inspector_plugin = FKEditorInspectorPlugin.new()
 	inspector_plugin.set_registry(action_registry)
-	inspector_plugin.set_editor_interface(get_editor_interface())
+	inspector_plugin.set_editor_interface(ed_interface)
 	add_inspector_plugin(inspector_plugin)
 
 	# Register export plugin to exclude unused providers from builds
-	export_plugin = preload("res://addons/flowkit/editor/export_plugin.gd").new()
+	export_plugin = FKExportPlugin.new()
 	export_plugin.set_generator(generator)
 	add_export_plugin(export_plugin)
 
-	print("[FlowKit] Plugin loaded")
+	print("[FlowKit]: Plugin loaded")
 
 func _exit_tree() -> void:
 	action_registry.free()

--- a/addons/flowkit/flowkit.gd
+++ b/addons/flowkit/flowkit.gd
@@ -2,7 +2,7 @@
 extends EditorPlugin
 
 var action_registry
-var editor
+var editor: FKMainEditor
 var generator
 var inspector_plugin
 var export_plugin
@@ -19,7 +19,8 @@ func _disable_plugin() -> void:
 func _enter_tree() -> void:
 	# Load UI
 	editor = preload("res://addons/flowkit/ui/main_editor.tscn").instantiate()
-
+	editor.legitimize()
+	
 	# Load registry
 	action_registry = preload("res://addons/flowkit/registry.gd").new()
 	action_registry.load_providers()

--- a/addons/flowkit/flowkit.gd
+++ b/addons/flowkit/flowkit.gd
@@ -18,8 +18,12 @@ func _disable_plugin() -> void:
 
 func _enter_tree() -> void:
 	# Load UI
-	editor = preload("res://addons/flowkit/ui/main_editor.tscn").instantiate()
+	print("[FlowKit] About to load main editor scene")
+	var editor_scene: PackedScene = preload("res://addons/flowkit/ui/main_editor.tscn")
+	print("[FlowKit] Loaded main editor scene. About to instantiate main editor.")
+	editor = editor_scene.instantiate()
 	editor.legitimize()
+	print("[FlowKit] Instantiated main editor.")
 	
 	# Load registry
 	action_registry = preload("res://addons/flowkit/registry.gd").new()
@@ -46,7 +50,12 @@ func _enter_tree() -> void:
 
 	# Add editor as main screen plugin
 	editor_main_screen = get_editor_interface().get_editor_main_screen()
+	print("[FlowKit] About to parent editor to main screen.")
 	editor_main_screen.add_child(editor)
+	print("[FlowKit] Added main editor to main screen. About to legitimize main editor.")
+	
+	
+	print("[FlowKit] Legitimized main editor")
 	# Hide by default until user clicks the FlowKit button
 	_make_visible(false)
 	

--- a/addons/flowkit/generator.gd
+++ b/addons/flowkit/generator.gd
@@ -32,7 +32,7 @@ func generate_all() -> Dictionary:
 	var node_types: Dictionary = {}
 	_collect_node_types(current_scene, node_types)
 	
-	print("[FlowKit Generator] Found ", node_types.size(), " unique node types")
+	print("[FKGenerator]: Found ", node_types.size(), " unique node types")
 	
 	# Generate providers for each node type
 	for node_type in node_types.keys():
@@ -671,9 +671,9 @@ func _write_file(path: String, content: String) -> void:
 	if file:
 		file.store_string(content)
 		file.close()
-		print("[FlowKit Generator] Created: ", path)
+		print("[FKGenerator]: Created: ", path)
 	else:
-		push_error("[FlowKit Generator] Failed to write: " + path)
+		push_error("[FKGenerator]: Failed to write: " + path)
 
 # ============================================================================
 # MANIFEST GENERATION
@@ -702,7 +702,7 @@ func generate_manifest() -> Dictionary:
 
 	# Step 1: Scan all event sheets and scenes to find actively used provider IDs
 	var used_ids: Dictionary = _scan_used_provider_ids()
-	print("[FlowKit Generator] Used provider IDs:")
+	print("[FKGenerator]: Used provider IDs:")
 	print("  Actions:    ", used_ids.action_ids)
 	print("  Conditions: ", used_ids.condition_ids)
 	print("  Events:     ", used_ids.event_ids)
@@ -762,10 +762,10 @@ func generate_manifest() -> Dictionary:
 	var error = ResourceSaver.save(manifest, MANIFEST_PATH)
 	if error != OK:
 		result.errors.append("Failed to save manifest: " + str(error))
-		push_error("[FlowKit Generator] Failed to save manifest: " + str(error))
+		push_error("[FKGenerator]: Failed to save manifest: " + str(error))
 	else:
-		print("[FlowKit Generator] Manifest saved to: ", MANIFEST_PATH)
-		print("[FlowKit Generator] Included: %d / %d providers (excluded %d unused)" % [
+		print("[FKGenerator]: Manifest saved to: ", MANIFEST_PATH)
+		print("[FKGenerator]: Included: %d / %d providers (excluded %d unused)" % [
 			result.total_included, result.total_available, result.total_excluded
 		])
 

--- a/addons/flowkit/registry.gd
+++ b/addons/flowkit/registry.gd
@@ -16,7 +16,7 @@ var branch_providers: Array = []
 func load_all() -> void:
 	# Try to load from manifest first (required for exported builds)
 	if _load_from_manifest():
-		print("[FlowKit Registry] Loaded providers from manifest: %d actions, %d conditions, %d events, %d behaviors, %d branches" % [
+		print("[FKRegistry] Loaded providers from manifest: %d actions, %d conditions, %d events, %d behaviors, %d branches" % [
 			action_providers.size(),
 			condition_providers.size(),
 			event_providers.size(),
@@ -34,7 +34,7 @@ func load_all() -> void:
 		_load_folder("behaviors", behavior_providers)
 		_load_folder("branches", branch_providers)
 		
-		print("[FlowKit Registry] Loaded providers from directories: %d actions, %d conditions, %d events, %d behaviors, %d branches" % [
+		print("[FKRegistry]: Loaded providers from directories: %d actions, %d conditions, %d events, %d behaviors, %d branches" % [
 			action_providers.size(),
 			condition_providers.size(),
 			event_providers.size(),
@@ -42,7 +42,7 @@ func load_all() -> void:
 			branch_providers.size()
 		])
 	else:
-		push_error("[FlowKit Registry] No provider manifest found and directory scanning is not available in exported builds. Generate the manifest in the editor.")
+		push_error("[FKRegistry]: No provider manifest found and directory scanning is not available in exported builds. Generate the manifest in the editor.")
 
 func load_providers() -> void:
 	# Alias for load_all() for backward compatibility

--- a/addons/flowkit/runtime/ActionInputs/action_input.gd
+++ b/addons/flowkit/runtime/ActionInputs/action_input.gd
@@ -33,10 +33,10 @@ func _get_raw(dict: Dictionary) -> Variant:
 	var result
 	if dict.has(name):
 		result = dict[name]
-		
-	var lower := name.to_lower()
-	if dict.has(lower):
-		result = dict[lower]
+	else:
+		var lower := name.to_lower()
+		if dict.has(lower):
+			result = dict[lower]
 	
 	if _is_valid(result):
 		return result

--- a/addons/flowkit/saved/event_sheet/2450759864276140733.tres
+++ b/addons/flowkit/saved/event_sheet/2450759864276140733.tres
@@ -91,7 +91,7 @@ block_type = "action"
 
 [sub_resource type="Resource" id="Resource_5nvf0"]
 script = ExtResource("2_o0xcg")
-block_id = "event_1775613196_2355312579"
+block_id = "event_1778576972_1574968030"
 event_id = "on_ready"
 target_node = NodePath(".")
 actions = Array[ExtResource("3_7puo2")]([SubResource("Resource_xv5k1"), SubResource("Resource_o0xcg"), SubResource("Resource_7puo2"), SubResource("Resource_ko5ym"), SubResource("Resource_v5tg8"), SubResource("Resource_l83bg")])

--- a/addons/flowkit/saved/event_sheet/4953409392252150460.tres
+++ b/addons/flowkit/saved/event_sheet/4953409392252150460.tres
@@ -39,7 +39,7 @@ block_type = "action"
 
 [sub_resource type="Resource" id="Resource_jqahe"]
 script = ExtResource("1_iqjwq")
-block_id = "event_1770855419_799863400"
+block_id = "event_1778968209_1373653493"
 event_id = "on_ready"
 target_node = NodePath(".")
 actions = Array[ExtResource("2_e5301")]([SubResource("Resource_6310v"), SubResource("Resource_1iq3u"), SubResource("Resource_cbhwn")])
@@ -178,7 +178,7 @@ block_type = "action"
 
 [sub_resource type="Resource" id="Resource_7khp5"]
 script = ExtResource("1_iqjwq")
-block_id = "event_1770855273_2148236877"
+block_id = "event_1778968209_2739151933"
 event_id = "on_process_physics"
 target_node = NodePath(".")
 actions = Array[ExtResource("2_e5301")]([SubResource("Resource_lifsa"), SubResource("Resource_ercbp"), SubResource("Resource_1geuf"), SubResource("Resource_iv7s5"), SubResource("Resource_01p3u"), SubResource("Resource_jtk1k")])
@@ -188,13 +188,7 @@ block_type = "event"
 script = ExtResource("5_1iq3u")
 title = "Movement"
 color = Color(0.4105078, 0.58125, 0, 1)
-children = [{
-"data": SubResource("Resource_jqahe"),
-"type": "event"
-}, {
-"data": SubResource("Resource_7khp5"),
-"type": "event"
-}]
+children = [SubResource("Resource_jqahe"), SubResource("Resource_7khp5")]
 block_type = "group"
 
 [sub_resource type="Resource" id="Resource_fwgt7"]
@@ -219,7 +213,7 @@ block_type = "condition"
 
 [sub_resource type="Resource" id="Resource_g1hr8"]
 script = ExtResource("1_iqjwq")
-block_id = "event_1764627242_1978017420"
+block_id = "event_1778968209_1371975470"
 event_id = "on_process_physics"
 target_node = NodePath(".")
 conditions = Array[ExtResource("3_6310v")]([SubResource("Resource_toik8")])
@@ -248,7 +242,7 @@ block_type = "condition"
 
 [sub_resource type="Resource" id="Resource_0864s"]
 script = ExtResource("1_iqjwq")
-block_id = "on_key_pressed_1734183459_0987654321"
+block_id = "event_1778968209_3083873755"
 event_id = "on_process_physics"
 target_node = NodePath(".")
 conditions = Array[ExtResource("3_6310v")]([SubResource("Resource_dkghy")])
@@ -259,13 +253,7 @@ block_type = "event"
 script = ExtResource("5_1iq3u")
 title = "Sets the direction of the player sprite to flip the sprite horizontally based on if the player is moving left or right."
 color = Color(0.16839236, 0.07305908, 0.4453125, 1)
-children = [{
-"data": SubResource("Resource_g1hr8"),
-"type": "event"
-}, {
-"data": SubResource("Resource_0864s"),
-"type": "event"
-}]
+children = [SubResource("Resource_g1hr8"), SubResource("Resource_0864s")]
 block_type = "group"
 
 [sub_resource type="Resource" id="Resource_rcr8d"]
@@ -303,7 +291,7 @@ block_type = "condition"
 
 [sub_resource type="Resource" id="Resource_7ahgf"]
 script = ExtResource("1_iqjwq")
-block_id = "event_1764826324_3494989596"
+block_id = "event_1778968209_3026241755"
 event_id = "on_process_physics"
 target_node = NodePath(".")
 conditions = Array[ExtResource("3_6310v")]([SubResource("Resource_lvjr6"), SubResource("Resource_1lc76")])
@@ -345,7 +333,7 @@ block_type = "condition"
 
 [sub_resource type="Resource" id="Resource_8cdef"]
 script = ExtResource("1_iqjwq")
-block_id = "event_1764826452_1205836981"
+block_id = "event_1778968209_2520809527"
 event_id = "on_process_physics"
 target_node = NodePath(".")
 conditions = Array[ExtResource("3_6310v")]([SubResource("Resource_olurx"), SubResource("Resource_a558m")])
@@ -356,19 +344,7 @@ block_type = "event"
 script = ExtResource("5_1iq3u")
 title = "Control animations"
 color = Color(0.38236463, 0.2642212, 0.7515625, 1)
-children = [{
-"data": SubResource("Resource_rcr8d"),
-"type": "comment"
-}, {
-"data": SubResource("Resource_7ahgf"),
-"type": "event"
-}, {
-"data": SubResource("Resource_rfu3m"),
-"type": "comment"
-}, {
-"data": SubResource("Resource_8cdef"),
-"type": "event"
-}]
+children = [SubResource("Resource_rcr8d"), SubResource("Resource_7ahgf"), SubResource("Resource_rfu3m"), SubResource("Resource_8cdef")]
 block_type = "group"
 
 [resource]

--- a/addons/flowkit/saved/event_sheet/6104984665772134237.tres
+++ b/addons/flowkit/saved/event_sheet/6104984665772134237.tres
@@ -78,7 +78,7 @@ block_type = "action"
 
 [sub_resource type="Resource" id="Resource_5spa6"]
 script = ExtResource("2_ju1rn")
-block_id = "event_1778570755_1389141348"
+block_id = "event_1778579360_2640092096"
 event_id = "on_ready"
 target_node = NodePath(".")
 actions = Array[ExtResource("3_5poua")]([SubResource("Resource_1axor"), SubResource("Resource_ju1rn"), SubResource("Resource_5poua"), SubResource("Resource_ayedq"), SubResource("Resource_np8on"), SubResource("Resource_v1ajb"), SubResource("Resource_e46t1")])

--- a/addons/flowkit/saved/event_sheet/6104984665772134237.tres
+++ b/addons/flowkit/saved/event_sheet/6104984665772134237.tres
@@ -9,18 +9,6 @@
 
 [sub_resource type="Resource" id="Resource_1axor"]
 script = ExtResource("3_5poua")
-action_id = "Print Message"
-target_node = NodePath(".")
-inputs = {
-"Color": "",
-"Message": "",
-"color": "",
-"message": "\"This is a message printed with the default color.\""
-}
-block_type = "action"
-
-[sub_resource type="Resource" id="Resource_ju1rn"]
-script = ExtResource("3_5poua")
 action_id = "set_window_size"
 target_node = NodePath("System")
 inputs = {
@@ -29,12 +17,22 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_5poua"]
+[sub_resource type="Resource" id="Resource_ju1rn"]
 script = ExtResource("3_5poua")
 action_id = "set_window_mode"
 target_node = NodePath("System")
 inputs = {
 "Mode": "\"windowed\""
+}
+block_type = "action"
+
+[sub_resource type="Resource" id="Resource_5poua"]
+script = ExtResource("3_5poua")
+action_id = "Print Message"
+target_node = NodePath(".")
+inputs = {
+"Color": "",
+"Message": "\"This is a message printed with the default color.\""
 }
 block_type = "action"
 
@@ -80,7 +78,7 @@ block_type = "action"
 
 [sub_resource type="Resource" id="Resource_5spa6"]
 script = ExtResource("2_ju1rn")
-block_id = "event_1775232152_1936602696"
+block_id = "event_1778570755_1389141348"
 event_id = "on_ready"
 target_node = NodePath(".")
 actions = Array[ExtResource("3_5poua")]([SubResource("Resource_1axor"), SubResource("Resource_ju1rn"), SubResource("Resource_5poua"), SubResource("Resource_ayedq"), SubResource("Resource_np8on"), SubResource("Resource_v1ajb"), SubResource("Resource_e46t1")])

--- a/addons/flowkit/saved/event_sheet/7830454191141003914.tres
+++ b/addons/flowkit/saved/event_sheet/7830454191141003914.tres
@@ -42,15 +42,6 @@ block_type = "action"
 
 [sub_resource type="Resource" id="Resource_ulxaw"]
 script = ExtResource("3_j21vh")
-action_id = "set_window_mode"
-target_node = NodePath("System")
-inputs = {
-"Mode": "windowed"
-}
-block_type = "action"
-
-[sub_resource type="Resource" id="Resource_rpy5k"]
-script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
 inputs = {
@@ -59,7 +50,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_efrgi"]
+[sub_resource type="Resource" id="Resource_rpy5k"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -69,7 +60,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_e6bne"]
+[sub_resource type="Resource" id="Resource_efrgi"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -79,7 +70,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_1h0yk"]
+[sub_resource type="Resource" id="Resource_e6bne"]
 script = ExtResource("3_j21vh")
 action_id = "Set Text"
 target_node = NodePath("DisplaysQuestion/QuestionText")
@@ -88,7 +79,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_7gjgi"]
+[sub_resource type="Resource" id="Resource_1h0yk"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -98,7 +89,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_njo67"]
+[sub_resource type="Resource" id="Resource_7gjgi"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -108,7 +99,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_7p70r"]
+[sub_resource type="Resource" id="Resource_njo67"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -118,7 +109,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_jl3cs"]
+[sub_resource type="Resource" id="Resource_7p70r"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -128,7 +119,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_y38jp"]
+[sub_resource type="Resource" id="Resource_jl3cs"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -138,7 +129,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_6grxg"]
+[sub_resource type="Resource" id="Resource_y38jp"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -148,7 +139,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_jpbjx"]
+[sub_resource type="Resource" id="Resource_6grxg"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -158,7 +149,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_ewbs2"]
+[sub_resource type="Resource" id="Resource_jpbjx"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -168,7 +159,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_7e0ye"]
+[sub_resource type="Resource" id="Resource_ewbs2"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -178,7 +169,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_yayi7"]
+[sub_resource type="Resource" id="Resource_7e0ye"]
 script = ExtResource("3_j21vh")
 action_id = "Set Text"
 target_node = NodePath("HoldsAnswers/FirstAnswerButton")
@@ -187,7 +178,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_4t33x"]
+[sub_resource type="Resource" id="Resource_yayi7"]
 script = ExtResource("3_j21vh")
 action_id = "Set Text"
 target_node = NodePath("HoldsAnswers/SecondAnswerButton")
@@ -196,7 +187,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_3wu3y"]
+[sub_resource type="Resource" id="Resource_4t33x"]
 script = ExtResource("3_j21vh")
 action_id = "Set Text"
 target_node = NodePath("HoldsAnswers/ThirdAnswerButton")
@@ -205,7 +196,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_8wvsr"]
+[sub_resource type="Resource" id="Resource_3wu3y"]
 script = ExtResource("3_j21vh")
 action_id = "Set Text"
 target_node = NodePath("HoldsAnswers/FourthAnswerButton")
@@ -214,7 +205,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_apwru"]
+[sub_resource type="Resource" id="Resource_8wvsr"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -224,7 +215,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_yrydo"]
+[sub_resource type="Resource" id="Resource_apwru"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -234,7 +225,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_hlcqt"]
+[sub_resource type="Resource" id="Resource_yrydo"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -244,7 +235,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_cfel1"]
+[sub_resource type="Resource" id="Resource_hlcqt"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -254,7 +245,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_fe1w8"]
+[sub_resource type="Resource" id="Resource_cfel1"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -264,7 +255,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_e0fgu"]
+[sub_resource type="Resource" id="Resource_fe1w8"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -274,7 +265,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_t47qt"]
+[sub_resource type="Resource" id="Resource_e0fgu"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -284,7 +275,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_icjx7"]
+[sub_resource type="Resource" id="Resource_t47qt"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -294,7 +285,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_o3aem"]
+[sub_resource type="Resource" id="Resource_icjx7"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -304,7 +295,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_bmqy2"]
+[sub_resource type="Resource" id="Resource_o3aem"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -314,7 +305,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_7fkax"]
+[sub_resource type="Resource" id="Resource_bmqy2"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -324,7 +315,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_f6ogq"]
+[sub_resource type="Resource" id="Resource_7fkax"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -334,7 +325,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_gajsv"]
+[sub_resource type="Resource" id="Resource_f6ogq"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -344,7 +335,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_e5g1r"]
+[sub_resource type="Resource" id="Resource_gajsv"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -354,7 +345,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_3pq7a"]
+[sub_resource type="Resource" id="Resource_e5g1r"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -364,15 +355,15 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_e3r8u"]
+[sub_resource type="Resource" id="Resource_3pq7a"]
 script = ExtResource("2_uoxok")
-block_id = "event_1775935370_3651881096"
+block_id = "event_1778579460_153282279"
 event_id = "on_ready"
 target_node = NodePath(".")
-actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_uoxok"), SubResource("Resource_j21vh"), SubResource("Resource_emcdn"), SubResource("Resource_ulxaw"), SubResource("Resource_rpy5k"), SubResource("Resource_efrgi"), SubResource("Resource_e6bne"), SubResource("Resource_1h0yk"), SubResource("Resource_7gjgi"), SubResource("Resource_njo67"), SubResource("Resource_7p70r"), SubResource("Resource_jl3cs"), SubResource("Resource_y38jp"), SubResource("Resource_6grxg"), SubResource("Resource_jpbjx"), SubResource("Resource_ewbs2"), SubResource("Resource_7e0ye"), SubResource("Resource_yayi7"), SubResource("Resource_4t33x"), SubResource("Resource_3wu3y"), SubResource("Resource_8wvsr"), SubResource("Resource_apwru"), SubResource("Resource_yrydo"), SubResource("Resource_hlcqt"), SubResource("Resource_cfel1"), SubResource("Resource_fe1w8"), SubResource("Resource_e0fgu"), SubResource("Resource_t47qt"), SubResource("Resource_icjx7"), SubResource("Resource_o3aem"), SubResource("Resource_bmqy2"), SubResource("Resource_7fkax"), SubResource("Resource_f6ogq"), SubResource("Resource_gajsv"), SubResource("Resource_e5g1r"), SubResource("Resource_3pq7a")])
+actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_uoxok"), SubResource("Resource_j21vh"), SubResource("Resource_emcdn"), SubResource("Resource_ulxaw"), SubResource("Resource_rpy5k"), SubResource("Resource_efrgi"), SubResource("Resource_e6bne"), SubResource("Resource_1h0yk"), SubResource("Resource_7gjgi"), SubResource("Resource_njo67"), SubResource("Resource_7p70r"), SubResource("Resource_jl3cs"), SubResource("Resource_y38jp"), SubResource("Resource_6grxg"), SubResource("Resource_jpbjx"), SubResource("Resource_ewbs2"), SubResource("Resource_7e0ye"), SubResource("Resource_yayi7"), SubResource("Resource_4t33x"), SubResource("Resource_3wu3y"), SubResource("Resource_8wvsr"), SubResource("Resource_apwru"), SubResource("Resource_yrydo"), SubResource("Resource_hlcqt"), SubResource("Resource_cfel1"), SubResource("Resource_fe1w8"), SubResource("Resource_e0fgu"), SubResource("Resource_t47qt"), SubResource("Resource_icjx7"), SubResource("Resource_o3aem"), SubResource("Resource_bmqy2"), SubResource("Resource_7fkax"), SubResource("Resource_f6ogq"), SubResource("Resource_gajsv"), SubResource("Resource_e5g1r")])
 block_type = "event"
 
-[sub_resource type="Resource" id="Resource_vvbgy"]
+[sub_resource type="Resource" id="Resource_e3r8u"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -382,7 +373,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_x3kut"]
+[sub_resource type="Resource" id="Resource_vvbgy"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -392,13 +383,13 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_2q5cv"]
+[sub_resource type="Resource" id="Resource_x3kut"]
 script = ExtResource("3_j21vh")
 action_id = "play"
 target_node = NodePath("CorrectVoiceClip")
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_4rioj"]
+[sub_resource type="Resource" id="Resource_2q5cv"]
 script = ExtResource("4_s7nm7")
 condition_id = "compare_variable"
 target_node = NodePath("System")
@@ -409,28 +400,28 @@ inputs = {
 }
 block_type = "condition"
 
-[sub_resource type="Resource" id="Resource_cpo3s"]
+[sub_resource type="Resource" id="Resource_4rioj"]
 script = ExtResource("3_j21vh")
 is_branch = true
 branch_type = "if"
-branch_condition = SubResource("Resource_4rioj")
-branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_x3kut"), SubResource("Resource_2q5cv")])
+branch_condition = SubResource("Resource_2q5cv")
+branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_vvbgy"), SubResource("Resource_x3kut")])
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_crlsd"]
+[sub_resource type="Resource" id="Resource_cpo3s"]
 script = ExtResource("3_j21vh")
 action_id = "play"
 target_node = NodePath("INcorrectVoiceClip")
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_ulr6u"]
+[sub_resource type="Resource" id="Resource_crlsd"]
 script = ExtResource("3_j21vh")
 is_branch = true
 branch_type = "else"
-branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_crlsd")])
+branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_cpo3s")])
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_iud1s"]
+[sub_resource type="Resource" id="Resource_ulr6u"]
 script = ExtResource("3_j21vh")
 action_id = "Print Message"
 target_node = NodePath(".")
@@ -440,15 +431,15 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_wccxq"]
+[sub_resource type="Resource" id="Resource_iud1s"]
 script = ExtResource("2_uoxok")
-block_id = "event_1775935370_2187878724"
+block_id = "event_1778579460_1803438691"
 event_id = "On Button Pressed"
 target_node = NodePath("HoldsAnswers/FirstAnswerButton")
-actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_vvbgy"), SubResource("Resource_cpo3s"), SubResource("Resource_ulr6u"), SubResource("Resource_iud1s")])
+actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_e3r8u"), SubResource("Resource_4rioj"), SubResource("Resource_crlsd"), SubResource("Resource_ulr6u")])
 block_type = "event"
 
-[sub_resource type="Resource" id="Resource_77cye"]
+[sub_resource type="Resource" id="Resource_wccxq"]
 script = ExtResource("3_j21vh")
 action_id = "Print Message"
 target_node = NodePath(".")
@@ -458,7 +449,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_e0h2c"]
+[sub_resource type="Resource" id="Resource_77cye"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -468,7 +459,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_fql5c"]
+[sub_resource type="Resource" id="Resource_e0h2c"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -478,13 +469,13 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_jvbn4"]
+[sub_resource type="Resource" id="Resource_fql5c"]
 script = ExtResource("3_j21vh")
 action_id = "play"
 target_node = NodePath("CorrectVoiceClip")
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_2i8k8"]
+[sub_resource type="Resource" id="Resource_jvbn4"]
 script = ExtResource("4_s7nm7")
 condition_id = "compare_variable"
 target_node = NodePath("System")
@@ -495,36 +486,36 @@ inputs = {
 }
 block_type = "condition"
 
-[sub_resource type="Resource" id="Resource_jj233"]
+[sub_resource type="Resource" id="Resource_2i8k8"]
 script = ExtResource("3_j21vh")
 is_branch = true
 branch_type = "if"
-branch_condition = SubResource("Resource_2i8k8")
-branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_fql5c"), SubResource("Resource_jvbn4")])
+branch_condition = SubResource("Resource_jvbn4")
+branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_e0h2c"), SubResource("Resource_fql5c")])
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_0gvro"]
+[sub_resource type="Resource" id="Resource_jj233"]
 script = ExtResource("3_j21vh")
 action_id = "play"
 target_node = NodePath("INcorrectVoiceClip")
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_v6ggk"]
+[sub_resource type="Resource" id="Resource_0gvro"]
 script = ExtResource("3_j21vh")
 is_branch = true
 branch_type = "else"
-branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_0gvro")])
+branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_jj233")])
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_2ae07"]
+[sub_resource type="Resource" id="Resource_v6ggk"]
 script = ExtResource("2_uoxok")
-block_id = "event_1775935370_2123418729"
+block_id = "event_1778579460_678760649"
 event_id = "On Button Pressed"
 target_node = NodePath("HoldsAnswers/SecondAnswerButton")
-actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_77cye"), SubResource("Resource_e0h2c"), SubResource("Resource_jj233"), SubResource("Resource_v6ggk")])
+actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_wccxq"), SubResource("Resource_77cye"), SubResource("Resource_2i8k8"), SubResource("Resource_0gvro")])
 block_type = "event"
 
-[sub_resource type="Resource" id="Resource_en1qb"]
+[sub_resource type="Resource" id="Resource_2ae07"]
 script = ExtResource("3_j21vh")
 action_id = "Print Message"
 target_node = NodePath(".")
@@ -534,7 +525,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_4a7op"]
+[sub_resource type="Resource" id="Resource_en1qb"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -544,7 +535,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_jvhj0"]
+[sub_resource type="Resource" id="Resource_4a7op"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -554,13 +545,13 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_18u5c"]
+[sub_resource type="Resource" id="Resource_jvhj0"]
 script = ExtResource("3_j21vh")
 action_id = "play"
 target_node = NodePath("CorrectVoiceClip")
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_a5vmf"]
+[sub_resource type="Resource" id="Resource_18u5c"]
 script = ExtResource("4_s7nm7")
 condition_id = "compare_variable"
 target_node = NodePath("System")
@@ -571,36 +562,36 @@ inputs = {
 }
 block_type = "condition"
 
-[sub_resource type="Resource" id="Resource_lp0wt"]
+[sub_resource type="Resource" id="Resource_a5vmf"]
 script = ExtResource("3_j21vh")
 is_branch = true
 branch_type = "if"
-branch_condition = SubResource("Resource_a5vmf")
-branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_jvhj0"), SubResource("Resource_18u5c")])
+branch_condition = SubResource("Resource_18u5c")
+branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_4a7op"), SubResource("Resource_jvhj0")])
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_gekfw"]
+[sub_resource type="Resource" id="Resource_lp0wt"]
 script = ExtResource("3_j21vh")
 action_id = "play"
 target_node = NodePath("INcorrectVoiceClip")
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_a6awu"]
+[sub_resource type="Resource" id="Resource_gekfw"]
 script = ExtResource("3_j21vh")
 is_branch = true
 branch_type = "else"
-branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_gekfw")])
+branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_lp0wt")])
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_m718d"]
+[sub_resource type="Resource" id="Resource_a6awu"]
 script = ExtResource("2_uoxok")
-block_id = "event_1775935370_2070493434"
+block_id = "event_1778579460_1030739966"
 event_id = "On Button Pressed"
 target_node = NodePath("HoldsAnswers/ThirdAnswerButton")
-actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_en1qb"), SubResource("Resource_4a7op"), SubResource("Resource_lp0wt"), SubResource("Resource_a6awu")])
+actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_2ae07"), SubResource("Resource_en1qb"), SubResource("Resource_a5vmf"), SubResource("Resource_gekfw")])
 block_type = "event"
 
-[sub_resource type="Resource" id="Resource_l7q4j"]
+[sub_resource type="Resource" id="Resource_m718d"]
 script = ExtResource("3_j21vh")
 action_id = "Print Message"
 target_node = NodePath(".")
@@ -610,7 +601,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_v4uwj"]
+[sub_resource type="Resource" id="Resource_l7q4j"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -620,7 +611,7 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_qjnoe"]
+[sub_resource type="Resource" id="Resource_v4uwj"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -630,13 +621,13 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_uvq0u"]
+[sub_resource type="Resource" id="Resource_qjnoe"]
 script = ExtResource("3_j21vh")
 action_id = "play"
 target_node = NodePath("CorrectVoiceClip")
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_ht44d"]
+[sub_resource type="Resource" id="Resource_uvq0u"]
 script = ExtResource("4_s7nm7")
 condition_id = "compare_variable"
 target_node = NodePath("System")
@@ -647,36 +638,36 @@ inputs = {
 }
 block_type = "condition"
 
-[sub_resource type="Resource" id="Resource_bieu4"]
+[sub_resource type="Resource" id="Resource_ht44d"]
 script = ExtResource("3_j21vh")
 is_branch = true
 branch_type = "if"
-branch_condition = SubResource("Resource_ht44d")
-branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_qjnoe"), SubResource("Resource_uvq0u")])
+branch_condition = SubResource("Resource_uvq0u")
+branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_v4uwj"), SubResource("Resource_qjnoe")])
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_po1c6"]
+[sub_resource type="Resource" id="Resource_bieu4"]
 script = ExtResource("3_j21vh")
 action_id = "play"
 target_node = NodePath("INcorrectVoiceClip")
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_6m3qi"]
+[sub_resource type="Resource" id="Resource_po1c6"]
 script = ExtResource("3_j21vh")
 is_branch = true
 branch_type = "else"
-branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_po1c6")])
+branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_bieu4")])
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_pcxsw"]
+[sub_resource type="Resource" id="Resource_6m3qi"]
 script = ExtResource("2_uoxok")
-block_id = "event_1775935370_1175266552"
+block_id = "event_1778579460_4039687986"
 event_id = "On Button Pressed"
 target_node = NodePath("HoldsAnswers/FourthAnswerButton")
-actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_l7q4j"), SubResource("Resource_v4uwj"), SubResource("Resource_bieu4"), SubResource("Resource_6m3qi")])
+actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_m718d"), SubResource("Resource_l7q4j"), SubResource("Resource_ht44d"), SubResource("Resource_po1c6")])
 block_type = "event"
 
-[sub_resource type="Resource" id="Resource_4gecw"]
+[sub_resource type="Resource" id="Resource_pcxsw"]
 script = ExtResource("3_j21vh")
 action_id = "Print Message"
 target_node = NodePath(".")
@@ -686,17 +677,17 @@ inputs = {
 }
 block_type = "action"
 
-[sub_resource type="Resource" id="Resource_7afg8"]
+[sub_resource type="Resource" id="Resource_4gecw"]
 script = ExtResource("2_uoxok")
-block_id = "event_1775935370_3956383849"
+block_id = "event_1778579460_3220777364"
 event_id = "On Text Changed"
 target_node = NodePath("HoldsAnswers/FirstAnswerButton")
-actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_4gecw")])
+actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_pcxsw")])
 block_type = "event"
 
 [resource]
 script = ExtResource("6_rpy5k")
-events = Array[ExtResource("2_uoxok")]([SubResource("Resource_e3r8u"), SubResource("Resource_wccxq"), SubResource("Resource_2ae07"), SubResource("Resource_m718d"), SubResource("Resource_pcxsw"), SubResource("Resource_7afg8")])
+events = Array[ExtResource("2_uoxok")]([SubResource("Resource_3pq7a"), SubResource("Resource_iud1s"), SubResource("Resource_v6ggk"), SubResource("Resource_a6awu"), SubResource("Resource_6m3qi"), SubResource("Resource_4gecw")])
 comments = Array[ExtResource("1_e8buc")]([SubResource("Resource_df7pu")])
 item_order = Array[Dictionary]([{
 "index": 0,

--- a/addons/flowkit/ui/inspector/flowkit_inspector_plugin.gd
+++ b/addons/flowkit/ui/inspector/flowkit_inspector_plugin.gd
@@ -1,5 +1,6 @@
 @tool
 extends EditorInspectorPlugin
+class_name FKEditorInspectorPlugin
 
 ## FlowKit Custom Inspector Plugin
 ## Adds FlowKit section to all nodes in the inspector

--- a/addons/flowkit/ui/main_editor.gd
+++ b/addons/flowkit/ui/main_editor.gd
@@ -49,7 +49,21 @@ var serializer := FKSerializationManager.new()
 var unit_ui_factory: FKUnitUiFactory
 var sheet_auto_saver: FKSheetAutoSaver = FKSheetAutoSaver.new()
 
+func legitimize():
+	if not is_editor_preview:
+		return
+	_is_editor_preview = false
+	_enter_tree()
+
+var is_editor_preview: bool:
+	get:
+		return _is_editor_preview
+		
+var _is_editor_preview := true
+
 func _enter_tree() -> void:
+	if is_editor_preview:
+		return
 	unit_ui_factory = FKUnitUiFactory.new(sheet_io)
 	sheet_auto_saver.init(self, auto_save_sheets)
 	input_manager.initialize(self)

--- a/addons/flowkit/ui/main_editor.gd
+++ b/addons/flowkit/ui/main_editor.gd
@@ -53,7 +53,16 @@ func _enter_tree() -> void:
 	unit_ui_factory = FKUnitUiFactory.new(sheet_io)
 	sheet_auto_saver.init(self, auto_save_sheets)
 	input_manager.initialize(self)
+	
+	_legitimize_modals()
 	_toggle_subs(true)
+
+func _legitimize_modals():
+	select_node_modal.legitimize()
+	select_event_modal.legitimize()
+	select_condition_modal.legitimize()
+	select_action_modal.legitimize()
+	expression_modal.legitimize()
 	
 func _toggle_subs(on: bool):
 	if on and not _is_subbed:
@@ -130,7 +139,8 @@ func _popup_centered_on_editor(popup: Window) -> void:
 	# Use editor_interface to get the actual main editor window
 	var editor_window: Window = null
 	if editor_interface:
-		editor_window = editor_interface.get_base_control().get_window()
+		var base_control := editor_interface.get_base_control()
+		editor_window = base_control.get_window()
 	
 	if not editor_window:
 		# Fallback to default behavior if window not available
@@ -1045,7 +1055,10 @@ func _start_add_workflow(block_type: String, target_row: Node = null) -> void:
 	_popup_centered_on_editor(select_node_modal)
 
 func _on_node_selected(node_path: String, node_class: String) -> void:
-	"""Node selected in workflow."""
+	"""
+	Node selected in workflow. This should execute when it's time to edit an FKUnit
+	through the editor.
+	"""
 	pending_node_path = node_path
 	select_node_modal.hide()
 	

--- a/addons/flowkit/ui/main_editor.gd
+++ b/addons/flowkit/ui/main_editor.gd
@@ -68,9 +68,52 @@ func _enter_tree() -> void:
 	sheet_auto_saver.init(self, auto_save_sheets)
 	input_manager.initialize(self)
 	
+	_ensure_we_have_modals()
+	_hide_modals()
 	_legitimize_modals()
 	_toggle_subs(true)
 
+func _ensure_we_have_modals():
+	var path: String
+	var scene: PackedScene = null
+	if not select_node_modal:
+		path = FKModalPaths.SELECT_NODE_MODAL
+		scene = load(path)
+		select_node_modal = scene.instantiate()
+		add_child(select_node_modal)
+		
+	if not select_event_modal:
+		path = FKModalPaths.SELECT_EVENT_MODAL
+		scene = load(path)
+		select_event_modal = scene.instantiate()
+		add_child(select_event_modal)
+		
+	if not select_condition_modal:
+		path = FKModalPaths.SELECT_CONDITION_MODAL
+		scene = load(path)
+		select_condition_modal = scene.instantiate()
+		add_child(select_condition_modal)
+		
+	if not select_action_modal:
+		path = FKModalPaths	.SELECT_ACTION_MODAL
+		scene = load(path)
+		select_action_modal = scene.instantiate()
+		add_child(select_action_modal)
+	
+	if not expression_modal:
+		path = FKModalPaths.EXPRESSION_EDITOR_MODAL
+		scene = load(path)
+		expression_modal = scene.instantiate()
+		add_child(expression_modal)
+		
+	
+func _hide_modals():
+	select_node_modal.visible = false
+	select_event_modal.visible = false
+	select_condition_modal.visible = false
+	select_action_modal.visible = false
+	expression_modal.visible = false
+	
 func _legitimize_modals():
 	select_node_modal.legitimize()
 	select_event_modal.legitimize()

--- a/addons/flowkit/ui/main_editor.gd
+++ b/addons/flowkit/ui/main_editor.gd
@@ -53,10 +53,12 @@ var unit_ui_factory: FKUnitUiFactory
 var sheet_auto_saver: FKSheetAutoSaver = FKSheetAutoSaver.new()
 
 func legitimize():
-	if not is_editor_preview:
+	if !is_editor_preview:
 		return
+	print("[FKMainEditor] Starting legitimization. Instance id: " + str(get_instance_id()))
 	_is_editor_preview = false
 	_enter_tree()
+	_is_legit = true
 
 var is_editor_preview: bool:
 	get:
@@ -66,12 +68,23 @@ var _is_editor_preview := true
 
 func _enter_tree() -> void:
 	if is_editor_preview:
+		print("[FKMainEditor] Entered tree as editor preview instance. Instance id: " + str(get_instance_id()))
 		return
+	if is_legit:
+		return
+	print("[FKMainEditor] Entered tree as legit instance. Instance id: " + str(get_instance_id()))
 	unit_ui_factory = FKUnitUiFactory.new(sheet_io)
 	sheet_auto_saver.init(self, auto_save_sheets)
 	input_manager.initialize(self)
 	_prep_modals()
 	_toggle_subs(true)
+
+var is_legit: bool:
+	get:
+		return _is_legit
+
+var _is_legit := false 
+# ^Need this to keep the same main editor instance from entering the tree twice
 
 func _prep_modals():
 	_create_modals()
@@ -121,19 +134,23 @@ func _hide_modals():
 		child.visible = false
 	
 func _legitimize_modals():
+	print("[FKMainEditor] Legitimizing modals")
 	for child in _modals:
 		child.legitimize()
 	
 func _toggle_subs(on: bool):
-	if on and not _is_subbed:
+	print("[FKMainEditor]: In _toggle_subs. on: " + str(on) + " | _is_subbed: " + str(_is_subbed))
+	if on and !_is_subbed:
 		# For undo state on drag-and-drop reorder
+		print("[FKMainEditor]: Listening for events")
 		blocks_container.before_block_moved.connect(_push_undo_state)
 		select_node_modal.node_selected.connect(_on_node_selected)
 		select_event_modal.event_selected.connect(_on_event_selected)
 		select_action_modal.action_selected.connect(_on_action_selected)
 		select_condition_modal.condition_selected.connect(_on_condition_selected)
 		expression_modal.expressions_confirmed.connect(_on_expressions_confirmed)
-	elif not on and _is_subbed:
+	elif !on and _is_subbed:
+		print("[FKMainEditor]: UNlistening for events")
 		blocks_container.before_block_moved.disconnect(_push_undo_state)
 		select_node_modal.node_selected.disconnect(_on_node_selected)
 		select_event_modal.event_selected.disconnect(_on_event_selected)
@@ -152,8 +169,9 @@ func _show_empty_state() -> void:
 	
 func _exit_tree() -> void:
 	if is_editor_preview:
+		print("[FKMainEditor] Exiting tree as editor preview. Instance id: " + str(get_instance_id()))
 		return
-	print("[FlowKitMainEditor] Exiting tree.")
+	print("[FlowKitMainEditor] Exiting tree as legit instance. Instance id: " + str(get_instance_id()))
 	_toggle_subs(false)
 
 func set_editor_interface(interface: EditorInterface) -> void:
@@ -1109,7 +1127,7 @@ func _on_node_selected(node_path: String, node_class: String) -> void:
 	"""
 	pending_node_path = node_path
 	select_node_modal.hide()
-	print("Node selected. Pending block type: " + pending_block_type)
+	print("[FKMainEditor]: Node selected. Pending block type: " + pending_block_type)
 	match pending_block_type:
 		"event", "event_replace", "event_in_group":
 			select_event_modal.populate_events(node_path, node_class)

--- a/addons/flowkit/ui/main_editor.gd
+++ b/addons/flowkit/ui/main_editor.gd
@@ -8,9 +8,12 @@ var registry: FKRegistry
 var generator
 var current_scene_uid: int = 0
 
+## Whether or not FlowKit auto-saves sheets in response to things
+## like adding or editing Actions.
 @export var auto_save_sheets: bool = true
 
 # UI References
+@export_category("UI")
 @export var scroll_container: ScrollContainer
 @export var blocks_container: FKBlockContainerUi
 @export var empty_label: Label
@@ -23,11 +26,11 @@ var drag_spacer_bottom: Control = null  # Temporary spacer at bottom during drag
 const DRAG_SPACER_HEIGHT := 50  # Height of temporary drop zone
 
 # Modals
-@export var select_node_modal: FKSelectNodeModal
-@export var select_event_modal: FKSelectEventModal
-@export var select_condition_modal: FKSelectConditionModal
-@export var select_action_modal: FKSelectActionModal
-@export var expression_modal: FKExpressionEditorModal
+var select_node_modal: FKSelectNodeModal
+var select_event_modal: FKSelectEventModal
+var select_condition_modal: FKSelectConditionModal
+var select_action_modal: FKSelectActionModal
+var expression_modal: FKExpressionEditorModal
 
 # Workflow state
 var pending_block_type: String = ""  # "event", "condition", "action", "event_replace", "event_in_group", etc.
@@ -67,59 +70,59 @@ func _enter_tree() -> void:
 	unit_ui_factory = FKUnitUiFactory.new(sheet_io)
 	sheet_auto_saver.init(self, auto_save_sheets)
 	input_manager.initialize(self)
-	
-	_ensure_we_have_modals()
-	_hide_modals()
-	_legitimize_modals()
+	_prep_modals()
 	_toggle_subs(true)
 
-func _ensure_we_have_modals():
+func _prep_modals():
+	_create_modals()
+	_refresh_modal_cache()
+	_hide_modals()
+	_legitimize_modals()
+	
+func _create_modals():
 	var path: String
 	var scene: PackedScene = null
-	if not select_node_modal:
-		path = FKModalPaths.SELECT_NODE_MODAL
-		scene = load(path)
-		select_node_modal = scene.instantiate()
-		add_child(select_node_modal)
-		
-	if not select_event_modal:
-		path = FKModalPaths.SELECT_EVENT_MODAL
-		scene = load(path)
-		select_event_modal = scene.instantiate()
-		add_child(select_event_modal)
-		
-	if not select_condition_modal:
-		path = FKModalPaths.SELECT_CONDITION_MODAL
-		scene = load(path)
-		select_condition_modal = scene.instantiate()
-		add_child(select_condition_modal)
-		
-	if not select_action_modal:
-		path = FKModalPaths	.SELECT_ACTION_MODAL
-		scene = load(path)
-		select_action_modal = scene.instantiate()
-		add_child(select_action_modal)
 	
-	if not expression_modal:
-		path = FKModalPaths.EXPRESSION_EDITOR_MODAL
-		scene = load(path)
-		expression_modal = scene.instantiate()
-		add_child(expression_modal)
+	path = FKModalPaths.SELECT_NODE_MODAL
+	scene = load(path)
+	select_node_modal = scene.instantiate()
+	add_child(select_node_modal)
 		
+	path = FKModalPaths.SELECT_EVENT_MODAL
+	scene = load(path)
+	select_event_modal = scene.instantiate()
+	add_child(select_event_modal)
+		
+	path = FKModalPaths.SELECT_CONDITION_MODAL
+	scene = load(path)
+	select_condition_modal = scene.instantiate()
+	add_child(select_condition_modal)
+		
+	path = FKModalPaths	.SELECT_ACTION_MODAL
+	scene = load(path)
+	select_action_modal = scene.instantiate()
+	add_child(select_action_modal)
 	
+	path = FKModalPaths.EXPRESSION_EDITOR_MODAL
+	scene = load(path)
+	expression_modal = scene.instantiate()
+	add_child(expression_modal)
+	
+func _refresh_modal_cache():
+	_modals.clear()
+	for child in get_children():
+		if child is FKModalWindow:
+			_modals.append(child)
+	
+var _modals: Array[FKModalWindow] = []
+
 func _hide_modals():
-	select_node_modal.visible = false
-	select_event_modal.visible = false
-	select_condition_modal.visible = false
-	select_action_modal.visible = false
-	expression_modal.visible = false
+	for child in _modals:
+		child.visible = false
 	
 func _legitimize_modals():
-	select_node_modal.legitimize()
-	select_event_modal.legitimize()
-	select_condition_modal.legitimize()
-	select_action_modal.legitimize()
-	expression_modal.legitimize()
+	for child in _modals:
+		child.legitimize()
 	
 func _toggle_subs(on: bool):
 	if on and not _is_subbed:
@@ -142,34 +145,26 @@ func _toggle_subs(on: bool):
 
 var _is_subbed := false
 
-func _setup_ui() -> void:
-	"""Initialize UI state."""
-	_show_empty_state()
-	
 func _show_empty_state() -> void:
 	"""Show empty state UI (no scene loaded)."""
 	empty_label.visible = true
 	add_event_btn.visible = false
 	
 func _exit_tree() -> void:
+	if is_editor_preview:
+		return
+	print("[FlowKitMainEditor] Exiting tree.")
 	_toggle_subs(false)
 
 func set_editor_interface(interface: EditorInterface) -> void:
 	editor_interface = interface
 	# Pass to modals (deferred in case they're not ready yet)
-	if select_node_modal:
-		select_node_modal.set_editor_interface(interface)
-	if select_event_modal:
-		select_event_modal.set_editor_interface(interface)
-	if select_condition_modal:
-		select_condition_modal.set_editor_interface(interface)
-	if select_action_modal:
-		select_action_modal.set_editor_interface(interface)
-	if expression_modal:
-		expression_modal.set_editor_interface(interface)
-	else:
-		# If modal isn't ready yet, defer it
-		call_deferred("_set_expression_interface", interface)
+	select_node_modal.set_editor_interface(interface)
+	select_event_modal.set_editor_interface(interface)
+	select_condition_modal.set_editor_interface(interface)
+	select_action_modal.set_editor_interface(interface)
+	expression_modal.set_editor_interface(interface)
+	expression_modal.set_editor_interface(interface)
 
 func set_registry(reg: FKRegistry) -> void:
 	registry = reg
@@ -539,10 +534,6 @@ func _find_parent_event_row(node: Control) -> FKEventRowUi:
 			return current
 		current = current.get_parent()
 	return null
-
-func _set_expression_interface(interface: EditorInterface) -> void:
-	if expression_modal:
-		expression_modal.set_editor_interface(interface)
 
 func undo(): _undo()
 func redo(): _redo()
@@ -1118,7 +1109,7 @@ func _on_node_selected(node_path: String, node_class: String) -> void:
 	"""
 	pending_node_path = node_path
 	select_node_modal.hide()
-	
+	print("Node selected. Pending block type: " + pending_block_type)
 	match pending_block_type:
 		"event", "event_replace", "event_in_group":
 			select_event_modal.populate_events(node_path, node_class)

--- a/addons/flowkit/ui/main_editor.gd
+++ b/addons/flowkit/ui/main_editor.gd
@@ -55,7 +55,7 @@ var sheet_auto_saver: FKSheetAutoSaver = FKSheetAutoSaver.new()
 func legitimize():
 	if !is_editor_preview:
 		return
-	print("[FKMainEditor] Starting legitimization. Instance id: " + str(get_instance_id()))
+	
 	_is_editor_preview = false
 	_enter_tree()
 	_is_legit = true
@@ -68,11 +68,11 @@ var _is_editor_preview := true
 
 func _enter_tree() -> void:
 	if is_editor_preview:
-		print("[FKMainEditor] Entered tree as editor preview instance. Instance id: " + str(get_instance_id()))
+		print("[FKMainEditor]: Entered tree as editor preview instance. Instance id: " + str(get_instance_id()))
 		return
 	if is_legit:
 		return
-	print("[FKMainEditor] Entered tree as legit instance. Instance id: " + str(get_instance_id()))
+	print("[FKMainEditor]: Entered tree as legit instance. Instance id: " + str(get_instance_id()))
 	unit_ui_factory = FKUnitUiFactory.new(sheet_io)
 	sheet_auto_saver.init(self, auto_save_sheets)
 	input_manager.initialize(self)
@@ -134,15 +134,12 @@ func _hide_modals():
 		child.visible = false
 	
 func _legitimize_modals():
-	print("[FKMainEditor] Legitimizing modals")
 	for child in _modals:
 		child.legitimize()
 	
 func _toggle_subs(on: bool):
-	print("[FKMainEditor]: In _toggle_subs. on: " + str(on) + " | _is_subbed: " + str(_is_subbed))
 	if on and !_is_subbed:
 		# For undo state on drag-and-drop reorder
-		print("[FKMainEditor]: Listening for events")
 		blocks_container.before_block_moved.connect(_push_undo_state)
 		select_node_modal.node_selected.connect(_on_node_selected)
 		select_event_modal.event_selected.connect(_on_event_selected)
@@ -150,7 +147,6 @@ func _toggle_subs(on: bool):
 		select_condition_modal.condition_selected.connect(_on_condition_selected)
 		expression_modal.expressions_confirmed.connect(_on_expressions_confirmed)
 	elif !on and _is_subbed:
-		print("[FKMainEditor]: UNlistening for events")
 		blocks_container.before_block_moved.disconnect(_push_undo_state)
 		select_node_modal.node_selected.disconnect(_on_node_selected)
 		select_event_modal.event_selected.disconnect(_on_event_selected)
@@ -169,9 +165,9 @@ func _show_empty_state() -> void:
 	
 func _exit_tree() -> void:
 	if is_editor_preview:
-		print("[FKMainEditor] Exiting tree as editor preview. Instance id: " + str(get_instance_id()))
+		print("[FKMainEditor]: Exiting tree as editor preview. Instance id: " + str(get_instance_id()))
 		return
-	print("[FlowKitMainEditor] Exiting tree as legit instance. Instance id: " + str(get_instance_id()))
+	print("[FKMainEditor]: Exiting tree as legit instance. Instance id: " + str(get_instance_id()))
 	_toggle_subs(false)
 
 func set_editor_interface(interface: EditorInterface) -> void:
@@ -405,22 +401,13 @@ func _undo() -> void:
 	if not undo_manager.can_undo() or _is_in_undo_redo:
 		return
 	_is_in_undo_redo = true
-	#print("[FKMainEditor]: Capturing units for undo")
 	var current_units := blocks_container.units
-	#print("[FKMainEditor]: Fetching prev state from undo manager")
 	var prev_state := undo_manager.undo(current_units)
 	var restored_units := ArrayUtils.get_fk_units_in(prev_state)
-	#print("[FKMainEditor]: Restored units after filter:")
-	for elem in restored_units:
-		print(elem.get_class() + ": " + str(elem))
-		if elem is FKGroup:
-			#print("[FKMainEditor]: It's a group")
-			pass
 	_restore_unit_uis(restored_units)
 	
 	_is_in_undo_redo = false
-	#print("[FKMainEditor]: About to save sheet after restoring units given by undo manager")
-	print("[FlowKit] Undo performed")
+	print("[FKMainEditor]: Undo performed")
 	
 var _is_in_undo_redo := false
 	
@@ -433,14 +420,12 @@ func _redo() -> void:
 
 	_restore_unit_uis(restored_units)
 	_is_in_undo_redo = false
-	print("[FlowKit] Redo performed")
+	print("[FKMainEditor]: Redo performed")
 
 func _restore_unit_uis(units: Array[FKUnit]) -> void:
 	blocks_container.clear_unit_nodes()
 
 	for unit in units:
-		#print("[FKMainEditor]: Current unit in _restore_unit_uis:")
-		#print(unit.get_class() + ": " + str(unit))
 		var node := _create_unit_ui(unit)
 		blocks_container.add_child(node)
 
@@ -449,13 +434,7 @@ func _restore_unit_uis(units: Array[FKUnit]) -> void:
 	else:
 		_show_empty_blocks_state()
 		
-	#print("[FKMainEditor]: blocks_container children after _restore_unit_uis:")
-	for elem in blocks_container.get_children():
-		#print(elem.get_class() + ": " + str(elem))
-		pass
 		
-
-
 func _create_unit_ui(unit: FKUnit) -> FKUnitUi:
 	var result: FKUnitUi = unit_ui_factory.unit_ui_from(unit)
 	if result:
@@ -706,10 +685,10 @@ func _save_sheet() -> FKEventSheet:
 	var err := sheet_io.save_sheet(current_scene_uid, sheet)
 	var result: FKEventSheet = null
 	if err == OK:
-		print("[FKMainEditor] ✓ Event sheet saved")
+		print("[FKMainEditor]: ✓ Event sheet saved")
 		result = sheet
 	else:
-		push_error("[FKMainEditor] Failed to save event sheet: ", err)
+		push_error("[FKMainEditor]: Failed to save event sheet: ", err)
 	
 	return result
 	
@@ -881,14 +860,14 @@ func _on_new_sheet() -> void:
 
 func _on_generate_providers() -> void:
 	if not generator:
-		print("[FlowKit] Generator not available")
+		print("[FKMainEditor]: Generator not available")
 		return
 	
-	print("[FlowKit] Starting provider generation...")
+	print("[FKMainEditor]: Starting provider generation...")
 	
 	var result = generator.generate_all()
 	
-	var message := "Generation complete!\n"
+	var message := "[FKMainEditor]: Generation complete!\n"
 	message += "Actions: %d\n" % result.actions
 	message += "Conditions: %d\n" % result.conditions
 	message += "Events: %d\n" % result.events
@@ -927,14 +906,14 @@ func _on_generate_providers() -> void:
 
 func _on_generate_manifest() -> void:
 	if not generator:
-		print("[FlowKit] Generator not available")
+		print("[FKMainEditor]: Generator not available")
 		return
 
-	print("[FlowKit] Generating optimized provider manifest for export...")
+	print("[FKMainEditor]: Generating optimized provider manifest for export...")
 
 	var result = generator.generate_manifest()
 
-	var message := "Optimized manifest generated!\n\n"
+	var message := "[FKMainEditor]: Optimized manifest generated!\n\n"
 	message += "Included providers (actively used):\n"
 	message += "  Actions:    %d\n" % result.actions
 	message += "  Conditions: %d\n" % result.conditions
@@ -1127,7 +1106,6 @@ func _on_node_selected(node_path: String, node_class: String) -> void:
 	"""
 	pending_node_path = node_path
 	select_node_modal.hide()
-	print("[FKMainEditor]: Node selected. Pending block type: " + pending_block_type)
 	match pending_block_type:
 		"event", "event_replace", "event_in_group":
 			select_event_modal.populate_events(node_path, node_class)
@@ -1151,7 +1129,6 @@ func _on_event_selected(node_path: String, event_id: String, inputs: Array) -> v
 	select_event_modal.hide()
 	
 	if inputs.size() > 0:
-		#print("[FKMainEditor] Populating inputs in on event selected")
 		expression_modal.populate_inputs(node_path, event_id, inputs)
 		_popup_centered_on_editor(expression_modal)
 	else:
@@ -1170,7 +1147,6 @@ func _on_condition_selected(node_path: String, condition_id: String, inputs: Arr
 	select_condition_modal.hide()
 	
 	if inputs.size() > 0:
-		#print("[FKMainEditor] Populating inputs in on condition selected")
 		expression_modal.populate_inputs(node_path, condition_id, inputs)
 		_popup_centered_on_editor(expression_modal)
 	else:
@@ -1187,12 +1163,10 @@ func _on_condition_selected(node_path: String, condition_id: String, inputs: Arr
 
 func _on_action_selected(node_path: String, action_id: String, inputs: Array) -> void:
 	"""Action type selected."""
-	#print("[FKMainEditor] Action selected")
 	pending_id = action_id
 	select_action_modal.hide()
 	
 	if inputs.size() > 0:
-		#print("[FKMainEditor] Populating inputs in on action selected")
 		expression_modal.populate_inputs(node_path, action_id, inputs)
 		_popup_centered_on_editor(expression_modal)
 	else:
@@ -1519,11 +1493,10 @@ func _on_row_edit(signal_row, bound_row: FKEventRowUi) -> void:
 		pending_node_path = str(data.target_node)
 		
 		# Open expression modal with current values
-		#print("[FKMainEditor] Populating inputs in on row edit")
 		expression_modal.populate_inputs(str(data.target_node), data.event_id, provider_inputs, data.inputs)
 		_popup_centered_on_editor(expression_modal)
 	else:
-		print("[FKMainEditor] Event has no inputs to edit")
+		print("[FKMainEditor]: Event has no inputs to edit")
 		pass
 
 func _on_row_add_condition(signal_row, bound_row: FKEventRowUi) -> void:
@@ -1694,11 +1667,10 @@ event_row: FKEventRowUi) -> void:
 		pending_block_type = "action_edit"
 		pending_id = act_data.action_id
 		pending_node_path = str(act_data.target_node)
-		#print("[FKMainEditor] Populating inputs in on branch action edit")
 		expression_modal.populate_inputs(str(act_data.target_node), act_data.action_id, provider_inputs, act_data.inputs)
 		_popup_centered_on_editor(expression_modal)
 	else:
-		print("[FKMainEditor] Action has no inputs to edit")
+		print("[FKMainEditor]: Action has no inputs to edit")
 
 func _finalize_branch_creation(inputs: Dictionary) -> void:
 	"""Create a condition-type branch and add it to the target's actions."""
@@ -1811,9 +1783,6 @@ func _update_branch_condition(expressions: Dictionary) -> void:
 
 func _finalize_branch_action_creation(inputs: Dictionary) -> void:
 	"""Add an action inside a branch."""
-	print("[FKMainEditor]: in _finalize_branch_action_creation. Inputs:")
-	print(str(inputs))
-	print("[FKMainEditor]: Pending target branch type: " + pending_target_branch.get_class())
 	_push_undo_state()
 
 	var data := FKActionUnit.new()
@@ -1848,7 +1817,6 @@ func _start_branch_workflow(branch_id: String, target_row) -> void:
 		pending_block_type = "branch_evaluation"
 		pending_target_row = target_row
 		if branch_inputs_def.size() > 0:
-			#print("[FKMainEditor] Populating inputs in start branch workflow")
 			expression_modal.populate_inputs("", branch_id, branch_inputs_def)
 			_popup_centered_on_editor(expression_modal)
 		else:
@@ -1943,11 +1911,10 @@ func _on_condition_edit_requested(condition_item: FKConditionUnitUi, bound_row) 
 		pending_block_type = "condition_edit"
 		pending_id = cond_data.condition_id
 		pending_node_path = str(cond_data.target_node)
-		#print("[FKMainEditor] Populating inputs in on condition edit requested")
 		expression_modal.populate_inputs(str(cond_data.target_node), cond_data.condition_id, provider_inputs, cond_data.inputs)
 		_popup_centered_on_editor(expression_modal)
 	else:
-		print("[FKMainEditor] Condition has no inputs to edit")
+		print("[FKMainEditor]: Condition has no inputs to edit")
 
 func _on_action_edit_requested(action_item: FKActionUnitUi, bound_row) -> void:
 	"""Handle double-click on action to edit its inputs."""
@@ -1962,8 +1929,6 @@ func _on_action_edit_requested(action_item: FKActionUnitUi, bound_row) -> void:
 			if provider.has_method("get_id") and provider.get_id() == act_data.action_id:
 				if provider is FKAction:
 					provider_inputs = provider.get_inputs()
-					#print("[FKMainEditor] Provider inputs found for provider type " + \
-					#provider.get_class() + ": " + str(provider_inputs))
 				break
 	
 	if provider_inputs.size() > 0:
@@ -1972,20 +1937,18 @@ func _on_action_edit_requested(action_item: FKActionUnitUi, bound_row) -> void:
 		pending_block_type = "action_edit"
 		pending_id = act_data.action_id
 		pending_node_path = str(act_data.target_node)
-		#print("[FKMainEditor] Populating inputs in on action edit requested. Provider inputs:\n" + str(provider_inputs))
 		var node_path := str(act_data.target_node)
 		expression_modal.populate_inputs(node_path, act_data.action_id, provider_inputs, \
 		act_data.inputs)
 		_popup_centered_on_editor(expression_modal)
 	else:
-		print("[FKMainEditor] Action has no inputs to edit")
+		print("[FKMainEditor]: Action has no inputs to edit")
 
 # === Drag and Drop Handlers ===
 
 func _on_condition_dropped(source_row: FKEventRowUi, condition_data: FKConditionUnit, 
 target_row: FKEventRowUi) -> void:
 	"""Handle condition dropped from one event row to another."""
-	print("[FKMainEditor] _on_condition_dropped")
 	if not source_row or not target_row or not condition_data:
 		return
 	
@@ -2008,7 +1971,6 @@ target_row: FKEventRowUi) -> void:
 
 func _on_action_dropped(source_row: FKEventRowUi, action_data: FKActionUnit, target_row: FKUnitUi) -> void:
 	"""Handle action dropped from one event row to another."""
-	print("[FKMainEditor] _on_action_dropped")
 	if not source_row or not target_row or not action_data:
 		return
 	

--- a/addons/flowkit/ui/main_editor.tscn
+++ b/addons/flowkit/ui/main_editor.tscn
@@ -179,9 +179,14 @@ visible = false
 position = Vector2i(0, 36)
 visible = false
 
-[node name="SelectConditionModal" parent="." unique_id=184117392 instance=ExtResource("7_pcxw6")]
+[node name="SelectConditionModal" parent="." unique_id=184117392 node_paths=PackedStringArray("search_box", "item_list", "description_label", "recent_item_list", "desc_panel") instance=ExtResource("7_pcxw6")]
 position = Vector2i(0, 36)
 visible = false
+search_box = NodePath("VBoxContainer/SearchBox")
+item_list = NodePath("VBoxContainer/HSplitContainer/MainPanel/MainVBox/ItemList")
+description_label = NodePath("VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel/ScrollContainer/DescriptionLabel")
+recent_item_list = NodePath("VBoxContainer/HSplitContainer/RecentPanel/RecentVBox/RecentItemList")
+desc_panel = NodePath("VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel")
 
 [node name="ExpressionModal" parent="." unique_id=996764360 instance=ExtResource("8_8w7jk")]
 visible = false

--- a/addons/flowkit/ui/main_editor.tscn
+++ b/addons/flowkit/ui/main_editor.tscn
@@ -3,11 +3,6 @@
 [ext_resource type="Script" uid="uid://bwh2bhg4rvhcx" path="res://addons/flowkit/ui/main_editor.gd" id="1_gkvd7"]
 [ext_resource type="Script" uid="uid://dg46wtoo70ju2" path="res://addons/flowkit/ui/menu_bar.gd" id="2_cq0bt"]
 [ext_resource type="Script" uid="uid://d3kkt2ew5wf7j" path="res://addons/flowkit/ui/blocks_container_ui.gd" id="3_xf0se"]
-[ext_resource type="PackedScene" uid="uid://buxqkjavs51qe" path="res://addons/flowkit/ui/modals/select_node_modal.tscn" id="4_t4gjw"]
-[ext_resource type="PackedScene" uid="uid://crj5y8vh2m3qi" path="res://addons/flowkit/ui/modals/select_event_modal.tscn" id="5_dqxt5"]
-[ext_resource type="PackedScene" uid="uid://c7j20avh3m4rj" path="res://addons/flowkit/ui/modals/select_action_modal.tscn" id="6_7k5ms"]
-[ext_resource type="PackedScene" uid="uid://cam4a1xj6n7ql" path="res://addons/flowkit/ui/modals/select_condition_modal.tscn" id="7_pcxw6"]
-[ext_resource type="PackedScene" uid="uid://d58fx0alhbxs" path="res://addons/flowkit/ui/modals/expression_editor.tscn" id="8_8w7jk"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_bg"]
 bg_color = Color(0.12, 0.12, 0.15, 1)
@@ -24,7 +19,7 @@ corner_radius_top_right = 6
 corner_radius_bottom_right = 6
 corner_radius_bottom_left = 6
 
-[node name="Control" type="Control" unique_id=945005444 node_paths=PackedStringArray("scroll_container", "blocks_container", "empty_label", "add_event_btn", "menu_bar", "select_node_modal", "select_event_modal", "select_condition_modal", "select_action_modal", "expression_modal")]
+[node name="Control" type="Control" unique_id=945005444 node_paths=PackedStringArray("scroll_container", "blocks_container", "empty_label", "add_event_btn", "menu_bar")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -39,11 +34,6 @@ blocks_container = NodePath("OuterVBox/ScrollContainer/MarginContainer/BlocksCon
 empty_label = NodePath("OuterVBox/ScrollContainer/MarginContainer/BlocksContainer/EmptyLabel")
 add_event_btn = NodePath("OuterVBox/BottomMargin/ButtonContainer/AddEventButton")
 menu_bar = NodePath("OuterVBox/TopMargin/TopBar/MenuBar")
-select_node_modal = NodePath("SelectNodeModal")
-select_event_modal = NodePath("SelectEventModal")
-select_condition_modal = NodePath("SelectConditionModal")
-select_action_modal = NodePath("SelectActionModal")
-expression_modal = NodePath("ExpressionModal")
 
 [node name="Background" type="Panel" parent="." unique_id=1222721060]
 layout_mode = 1
@@ -168,28 +158,6 @@ theme_override_styles/normal = SubResource("StyleBoxFlat_button")
 theme_override_styles/pressed = SubResource("StyleBoxFlat_button")
 theme_override_styles/hover = SubResource("StyleBoxFlat_button")
 text = "➕ Add Event"
-
-[node name="SelectNodeModal" parent="." unique_id=2030002633 instance=ExtResource("4_t4gjw")]
-visible = false
-
-[node name="SelectEventModal" parent="." unique_id=2026572997 instance=ExtResource("5_dqxt5")]
-visible = false
-
-[node name="SelectActionModal" parent="." unique_id=374370571 instance=ExtResource("6_7k5ms")]
-position = Vector2i(0, 36)
-visible = false
-
-[node name="SelectConditionModal" parent="." unique_id=184117392 node_paths=PackedStringArray("search_box", "item_list", "description_label", "recent_item_list", "desc_panel") instance=ExtResource("7_pcxw6")]
-position = Vector2i(0, 36)
-visible = false
-search_box = NodePath("VBoxContainer/SearchBox")
-item_list = NodePath("VBoxContainer/HSplitContainer/MainPanel/MainVBox/ItemList")
-description_label = NodePath("VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel/ScrollContainer/DescriptionLabel")
-recent_item_list = NodePath("VBoxContainer/HSplitContainer/RecentPanel/RecentVBox/RecentItemList")
-desc_panel = NodePath("VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel")
-
-[node name="ExpressionModal" parent="." unique_id=996764360 instance=ExtResource("8_8w7jk")]
-visible = false
 
 [connection signal="generate_manifest" from="OuterVBox/TopMargin/TopBar/MenuBar" to="." method="_on_generate_manifest"]
 [connection signal="generate_providers" from="OuterVBox/TopMargin/TopBar/MenuBar" to="." method="_on_generate_providers"]

--- a/addons/flowkit/ui/main_editor.tscn
+++ b/addons/flowkit/ui/main_editor.tscn
@@ -170,6 +170,7 @@ theme_override_styles/hover = SubResource("StyleBoxFlat_button")
 text = "➕ Add Event"
 
 [node name="SelectNodeModal" parent="." unique_id=2030002633 instance=ExtResource("4_t4gjw")]
+visible = false
 
 [node name="SelectEventModal" parent="." unique_id=2026572997 instance=ExtResource("5_dqxt5")]
 visible = false

--- a/addons/flowkit/ui/main_editor.tscn
+++ b/addons/flowkit/ui/main_editor.tscn
@@ -176,10 +176,15 @@ visible = false
 visible = false
 
 [node name="SelectActionModal" parent="." unique_id=374370571 instance=ExtResource("6_7k5ms")]
+position = Vector2i(0, 36)
+visible = false
 
 [node name="SelectConditionModal" parent="." unique_id=184117392 instance=ExtResource("7_pcxw6")]
+position = Vector2i(0, 36)
+visible = false
 
 [node name="ExpressionModal" parent="." unique_id=996764360 instance=ExtResource("8_8w7jk")]
+visible = false
 
 [connection signal="generate_manifest" from="OuterVBox/TopMargin/TopBar/MenuBar" to="." method="_on_generate_manifest"]
 [connection signal="generate_providers" from="OuterVBox/TopMargin/TopBar/MenuBar" to="." method="_on_generate_providers"]

--- a/addons/flowkit/ui/modals/expression_editor.tscn
+++ b/addons/flowkit/ui/modals/expression_editor.tscn
@@ -14,6 +14,7 @@ oversampling_override = 1.0
 title = "Expression Editor"
 position = Vector2i(0, 36)
 size = Vector2i(800, 600)
+visible = true
 unresizable = false
 borderless = false
 keep_title_visible = true

--- a/addons/flowkit/ui/modals/expression_editor_modal.gd
+++ b/addons/flowkit/ui/modals/expression_editor_modal.gd
@@ -1,10 +1,9 @@
 @tool
-extends PopupPanel
+extends FKModalWindow
 class_name FKExpressionEditorModal
 
 signal expressions_confirmed(node_path: String, action_id: String, expressions: Dictionary)
 
-var editor_interface: EditorInterface
 var selected_node_path: String = ""
 var selected_action_id: String = ""
 var action_inputs: Array = []
@@ -23,31 +22,20 @@ var param_values: Dictionary = {}
 
 var selected_tree_node: Node = null
 
-func legitimize():
-	if not is_editor_preview:
-		return
-	_is_editor_preview = false
-	_enter_tree()
-
-var is_editor_preview: bool:
-	get:
-		return _is_editor_preview
-		
-var _is_editor_preview := true
-
 func _enter_tree() -> void:
+	super._enter_tree()
+	
 	if is_editor_preview:
 		return
 		
-	_toggle_subs(true)
-	if editor_interface:
+	if _editor_interface:
 		_setup_node_tree.call_deferred()
 
 func _toggle_subs(on: bool):
 	if on and not _is_subbed:
 		node_tree.item_selected.connect(_on_node_selected)
 		item_list.item_activated.connect(_on_item_activated)
-	elif _is_subbed and !on:
+	elif _is_subbed and not on:
 		node_tree.item_selected.disconnect(_on_node_selected)
 		item_list.item_activated.disconnect(_on_item_activated)
 	else:
@@ -55,18 +43,12 @@ func _toggle_subs(on: bool):
 	
 	_is_subbed = on
 
-var _is_subbed := false
-
 func set_editor_interface(interface: EditorInterface) -> void:
-	editor_interface = interface
+	var already_had_it: bool = _editor_interface != null
+	super.set_editor_interface(interface)
 	# Setup tree if we're already ready
-	if is_node_ready():
+	if not already_had_it:
 		_setup_node_tree.call_deferred()
-
-func set_registry(reg: FKRegistry):
-	registry = reg
-	
-var registry: FKRegistry
 
 func populate_inputs(node_path: String, action_id: String, inputs: Array, \
 current_values: Dictionary = {}) -> void:
@@ -79,11 +61,11 @@ current_values: Dictionary = {}) -> void:
 	_show_current_parameter()
 	
 	# Setup node tree if editor interface is available
-	if editor_interface:
+	if _editor_interface:
 		_setup_node_tree()
 
 func _setup_node_tree() -> void:
-	if not editor_interface:
+	if not _editor_interface:
 		return
 	
 	node_tree.clear()
@@ -91,7 +73,7 @@ func _setup_node_tree() -> void:
 	if not _scene_root:
 		return
 	
-	_base_control = editor_interface.get_base_control()
+	_base_control = _editor_interface.get_base_control()
 	_add_sys_node_entry()
 	var root_item := _create_root_item()
 	_add_node_children(_scene_root, root_item)
@@ -121,7 +103,7 @@ func _add_node_children(node: Node, tree_item: TreeItem) -> void:
 		
 		# Get node icon from editor
 		var icon_name: String = child.get_class()
-		var base_control := editor_interface.get_base_control()
+		var base_control := _editor_interface.get_base_control()
 		var icon: Texture2D = base_control.get_theme_icon(icon_name, "EditorIcons")
 		if icon:
 			child_item.set_icon(0, icon)
@@ -203,7 +185,7 @@ func _populate_item_list_for_selected_node() -> void:
 
 var _scene_root: Node:
 	get:
-		return editor_interface.get_edited_scene_root() if editor_interface else null
+		return _editor_interface.get_edited_scene_root() if _editor_interface else null
 		
 func _add_var_items(target_node: Node):
 	if not selected_tree_node.has_meta("flowkit_variables"):

--- a/addons/flowkit/ui/modals/expression_editor_modal.gd
+++ b/addons/flowkit/ui/modals/expression_editor_modal.gd
@@ -113,24 +113,24 @@ func _add_node_children(node: Node, tree_item: TreeItem) -> void:
 			_add_node_children(child, child_item)
 
 func _show_current_parameter() -> void:
-	print("In show current param")
+	print("[FKExpressionEditorModal]: In show current param")
 	if action_inputs.is_empty():
-		print("Action inputs are empty. Doing nothing.")
+		print("[FKExpressionEditorModal]: Action inputs are empty. Doing nothing.")
 		return
 	
-	print("Action inputs:\n" + str(action_inputs))
+	print("[FKExpressionEditorModal]: Action inputs:\n" + str(action_inputs))
 	var current_input = action_inputs[current_param_index]
 	var param_name: String; var param_type: String; var param_description: String;
 	var fk_action_input: FKActionInput
 	if current_input is Dictionary:
-		print("Current input is dict")
+		print("[FKExpressionEditorModal]: Current input is dict")
 		var param_dict: Dictionary = action_inputs[current_param_index]
 		param_name = param_dict.get("name", "Unknown")
 		param_type = param_dict.get("type", "Variant")
 		param_description = param_dict.get("description", "")
 		
 	elif current_input is FKActionInput:
-		print("Current input is FKActionInput")
+		print("[FKExpressionEditorModal]: Current input is FKActionInput")
 		fk_action_input = current_input
 		param_name = fk_action_input.name
 		param_type = fk_action_input.type

--- a/addons/flowkit/ui/modals/expression_editor_modal.gd
+++ b/addons/flowkit/ui/modals/expression_editor_modal.gd
@@ -50,6 +50,8 @@ func _toggle_subs(on: bool):
 	elif _is_subbed and !on:
 		node_tree.item_selected.disconnect(_on_node_selected)
 		item_list.item_activated.disconnect(_on_item_activated)
+	else:
+		return
 	
 	_is_subbed = on
 
@@ -392,5 +394,3 @@ func _confirm() -> void:
 func _on_cancel_button_pressed() -> void:
 	hide()
 	
-func _exit_tree() -> void:
-	_toggle_subs(false)

--- a/addons/flowkit/ui/modals/expression_editor_modal.gd
+++ b/addons/flowkit/ui/modals/expression_editor_modal.gd
@@ -23,23 +23,43 @@ var param_values: Dictionary = {}
 
 var selected_tree_node: Node = null
 
+func legitimize():
+	if not is_editor_preview:
+		return
+	_is_editor_preview = false
+	_enter_tree()
+
+var is_editor_preview: bool:
+	get:
+		return _is_editor_preview
+		
+var _is_editor_preview := true
+
 func _enter_tree() -> void:
+	if is_editor_preview:
+		return
+		
 	_toggle_subs(true)
 	if editor_interface:
-		call_deferred("_setup_node_tree")
+		_setup_node_tree.call_deferred()
 
 func _toggle_subs(on: bool):
-	if on:
+	if on and not _is_subbed:
 		node_tree.item_selected.connect(_on_node_selected)
 		item_list.item_activated.connect(_on_item_activated)
-		if editor_interface:
-			call_deferred("_setup_node_tree")
+	elif _is_subbed and !on:
+		node_tree.item_selected.disconnect(_on_node_selected)
+		item_list.item_activated.disconnect(_on_item_activated)
 	
+	_is_subbed = on
+
+var _is_subbed := false
+
 func set_editor_interface(interface: EditorInterface) -> void:
 	editor_interface = interface
 	# Setup tree if we're already ready
 	if is_node_ready():
-		call_deferred("_setup_node_tree")
+		_setup_node_tree.call_deferred()
 
 func set_registry(reg: FKRegistry):
 	registry = reg
@@ -69,20 +89,27 @@ func _setup_node_tree() -> void:
 	if not _scene_root:
 		return
 	
-	# Add System node as first entry (runtime autoload)
+	_base_control = editor_interface.get_base_control()
+	_add_sys_node_entry()
+	var root_item := _create_root_item()
+	_add_node_children(_scene_root, root_item)
+
+var _base_control: Control
+
+func _add_sys_node_entry():
+	# The System Node should be a runtime Autoload.
 	var system_item: TreeItem = node_tree.create_item()
 	system_item.set_text(0, "System (FlowKitSystem)")
 	system_item.set_metadata(0, null)  # No actual node in editor
-	system_item.set_icon(0, editor_interface.get_base_control().get_theme_icon("Node", "EditorIcons"))
+	system_item.set_icon(0, _base_control.get_theme_icon("Node", "EditorIcons"))
 	
-	# Create root item
+func _create_root_item() -> TreeItem:
 	var root_item: TreeItem = node_tree.create_item()
 	root_item.set_text(0, _scene_root.name)
 	root_item.set_metadata(0, _scene_root)
-	root_item.set_icon(0, editor_interface.get_base_control().get_theme_icon("Node", "EditorIcons"))
+	root_item.set_icon(0, _base_control.get_theme_icon("Node", "EditorIcons"))
+	return root_item
 	
-	# Recursively add children
-	_add_node_children(_scene_root, root_item)
 
 func _add_node_children(node: Node, tree_item: TreeItem) -> void:
 	for child in node.get_children():
@@ -145,7 +172,8 @@ func _update_expr_input(param_name: String):
 func _update_nav_buttons():
 	prev_button.disabled = current_param_index == 0
 	next_button.disabled = current_param_index >= action_inputs.size() - 1
-	confirm_button.text = "Confirm" if current_param_index >= action_inputs.size() - 1 else "Next"
+	confirm_button.text = "Confirm" if current_param_index >= action_inputs.size() - 1 \
+	else "Next"
 	
 func _on_node_selected() -> void:
 	var selected_item: TreeItem = node_tree.get_selected()

--- a/addons/flowkit/ui/modals/select_action_modal.gd
+++ b/addons/flowkit/ui/modals/select_action_modal.gd
@@ -73,7 +73,7 @@ func _load_available_actions() -> void:
 	available_actions.clear()
 	var actions_path: String = "res://addons/flowkit/actions"
 	_scan_directory_recursive(actions_path)
-	print("Loaded ", available_actions.size(), " actions")
+	print("[FKSelectActionModal]: Loaded ", available_actions.size(), " actions")
 
 func _scan_directory_recursive(path: String) -> void:
 	"""Recursively scan directories for action scripts."""
@@ -182,7 +182,7 @@ func _on_item_activated(index: int) -> void:
 			action_name = action.get_name()
 			break
 	
-	print("Action selected: ", action_id, " for node: ", selected_node_path)
+	print("[FKSelectActionModal]: Action selected: ", action_id, " for node: ", selected_node_path)
 	_recent_items_manager.add_recent_action(action_id, action_name, selected_node_class)
 	action_selected.emit(selected_node_path, action_id, inputs)
 	hide()
@@ -244,6 +244,6 @@ func _on_recent_item_activated(index: int) -> void:
 			action_inputs = action.get_inputs()
 			break
 	
-	print("Recent action selected: ", action_id, " for node: ", selected_node_path)
+	print("[FKSelectActionModal]: Recent action selected: ", action_id, " for node: ", selected_node_path)
 	action_selected.emit(selected_node_path, action_id, action_inputs)
 	hide()

--- a/addons/flowkit/ui/modals/select_action_modal.gd
+++ b/addons/flowkit/ui/modals/select_action_modal.gd
@@ -21,7 +21,7 @@ var _recent_items_manager: Variant = null
 
 func _enter_tree() -> void:
 	super._enter_tree()
-	if is_editor_preview:
+	if is_editor_preview or is_fully_legit:
 		return
 		
 	_recent_items_manager = FKRecentItemsManagerUi.new()

--- a/addons/flowkit/ui/modals/select_action_modal.gd
+++ b/addons/flowkit/ui/modals/select_action_modal.gd
@@ -1,5 +1,5 @@
 @tool
-extends PopupPanel
+extends FKModalWindow
 class_name FKSelectActionModal
 
 signal action_selected(node_path: String, action_id: String, action_inputs: Array)
@@ -19,36 +19,11 @@ var available_actions: Array = []
 var _all_items_cache: Array = []
 var _recent_items_manager: Variant = null
 
-func set_editor_interface(interface: EditorInterface) -> void:
-	editor_interface = interface
-	
-var editor_interface: EditorInterface
-
-
-func legitimize():
-	if not is_editor_preview:
-		return
-	_is_editor_preview = false
-	_enter_tree()
-
-var is_editor_preview: bool:
-	get:
-		return _is_editor_preview
-		
-var _is_editor_preview := true
-
-func set_registry(reg: FKRegistry):
-	registry = reg
-	
-var registry: FKRegistry
-
 func _enter_tree() -> void:
+	super._enter_tree()
 	if is_editor_preview:
 		return
 		
-	_ensure_export_fields_filled()
-	_set_desc_panel_style()
-	_toggle_subs(true)
 	_recent_items_manager = FKRecentItemsManagerUi.new()
 	_load_available_actions()
 
@@ -78,23 +53,21 @@ func _ensure_export_fields_filled():
 func _set_desc_panel_style():
 	desc_panel.add_theme_stylebox_override("panel", desc_panel_style)
 	
-func _toggle_subs(on: bool):
-	if on and not _is_subbed:
+func _toggle_subs(should_sub: bool):
+	if should_sub and not _is_subbed:
 		search_box.text_changed.connect(_on_search_text_changed)
 		item_list.item_activated.connect(_on_item_activated)
 		item_list.item_selected.connect(_on_item_selected)
 		recent_item_list.item_activated.connect(_on_recent_item_activated)
 
-	elif _is_subbed and !on:
+	elif _is_subbed and !should_sub:
 		search_box.text_changed.disconnect(_on_search_text_changed)
 		item_list.item_activated.disconnect(_on_item_activated)
 		item_list.item_selected.disconnect(_on_item_selected)
 		recent_item_list.item_activated.disconnect(_on_recent_item_activated)
 		
-	_is_subbed = on
+	_is_subbed = should_sub
 	
-var _is_subbed := false
-
 func _load_available_actions() -> void:
 	"""Load all action scripts from the actions folder."""
 	available_actions.clear()

--- a/addons/flowkit/ui/modals/select_action_modal.gd
+++ b/addons/flowkit/ui/modals/select_action_modal.gd
@@ -8,10 +8,13 @@ var selected_node_path: String = ""
 var selected_node_class: String = ""
 var available_actions: Array = []
 
-@onready var search_box := $VBoxContainer/SearchBox
-@onready var item_list := $VBoxContainer/HSplitContainer/MainPanel/MainVBox/ItemList
-@onready var description_label := $VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel/ScrollContainer/DescriptionLabel
-@onready var recent_item_list := $VBoxContainer/HSplitContainer/RecentPanel/RecentVBox/RecentItemList
+@export var search_box: LineEdit
+@export var item_list: ItemList
+@export var description_label: Label
+@export var recent_item_list: ItemList
+
+@export var desc_panel: Panel
+@export var desc_panel_style: StyleBoxFlat
 
 var _all_items_cache: Array = []
 var _recent_items_manager: Variant = null
@@ -21,33 +24,76 @@ func set_editor_interface(interface: EditorInterface) -> void:
 	
 var editor_interface: EditorInterface
 
+
+func legitimize():
+	if not is_editor_preview:
+		return
+	_is_editor_preview = false
+	_enter_tree()
+
+var is_editor_preview: bool:
+	get:
+		return _is_editor_preview
+		
+var _is_editor_preview := true
+
 func set_registry(reg: FKRegistry):
 	registry = reg
 	
 var registry: FKRegistry
 
-func _ready() -> void:
-	if search_box:
-		search_box.text_changed.connect(_on_search_text_changed)
+func _enter_tree() -> void:
+	if is_editor_preview:
+		return
 		
-	if item_list:
+	_ensure_export_fields_filled()
+	_set_desc_panel_style()
+	_toggle_subs(true)
+	_recent_items_manager = FKRecentItemsManagerUi.new()
+	_load_available_actions()
+
+func _ensure_export_fields_filled():
+	var path: String
+	if not search_box:
+		path = "VBoxContainer/SearchBox"
+		search_box = get_node(path)
+		
+	if not item_list:
+		path = "VBoxContainer/HSplitContainer/MainPanel/MainVBox/ItemList"
+		item_list = get_node(path)
+		
+	if not description_label:
+		path = "VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel/" +\
+		"ScrollContainer/DescriptionLabel"
+		description_label = get_node(path)
+		
+	if not recent_item_list:
+		path = "VBoxContainer/HSplitContainer/RecentPanel/RecentVBox/RecentItemList"
+		recent_item_list = get_node(path)
+		
+	if not desc_panel:
+		path = "VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel"
+		desc_panel = get_node(path)
+	
+func _set_desc_panel_style():
+	desc_panel.add_theme_stylebox_override("panel", desc_panel_style)
+	
+func _toggle_subs(on: bool):
+	if on and not _is_subbed:
+		search_box.text_changed.connect(_on_search_text_changed)
 		item_list.item_activated.connect(_on_item_activated)
 		item_list.item_selected.connect(_on_item_selected)
-	
-	if recent_item_list:
 		recent_item_list.item_activated.connect(_on_recent_item_activated)
+
+	elif _is_subbed and !on:
+		search_box.text_changed.disconnect(_on_search_text_changed)
+		item_list.item_activated.disconnect(_on_item_activated)
+		item_list.item_selected.disconnect(_on_item_selected)
+		recent_item_list.item_activated.disconnect(_on_recent_item_activated)
+		
+	_is_subbed = on
 	
-	# Set description panel style
-	var panel = $VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel
-	var style = StyleBoxFlat.new()
-	style.bg_color = Color(0.2, 0.2, 0.2, 0.8)
-	panel.add_theme_stylebox_override("panel", style)
-	
-	# Load recent items manager
-	_recent_items_manager = load("res://addons/flowkit/ui/modals/recent_items_manager.gd").new()
-	
-	# Load all available actions
-	_load_available_actions()
+var _is_subbed := false
 
 func _load_available_actions() -> void:
 	"""Load all action scripts from the actions folder."""

--- a/addons/flowkit/ui/modals/select_action_modal.tscn
+++ b/addons/flowkit/ui/modals/select_action_modal.tscn
@@ -2,17 +2,29 @@
 
 [ext_resource type="Script" uid="uid://ckts6rjlmh4hr" path="res://addons/flowkit/ui/modals/select_action_modal.gd" id="1_action"]
 
-[node name="SelectAction" type="PopupPanel"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_3qifl"]
+bg_color = Color(0.2, 0.2, 0.2, 0.8)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_fkpqk"]
+bg_color = Color(0.2, 0.2, 0.2, 0.8)
+
+[node name="SelectAction" type="PopupPanel" unique_id=1297607050 node_paths=PackedStringArray("search_box", "item_list", "description_label", "recent_item_list", "desc_panel")]
 oversampling_override = 1.0
 title = "Select an Action"
-initial_position = 0
 size = Vector2i(900, 600)
+visible = true
+unresizable = false
 borderless = false
 keep_title_visible = true
-unresizable = false
 script = ExtResource("1_action")
+search_box = NodePath("VBoxContainer/SearchBox")
+item_list = NodePath("VBoxContainer/HSplitContainer/MainPanel/MainVBox/ItemList")
+description_label = NodePath("VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel/ScrollContainer/DescriptionLabel")
+recent_item_list = NodePath("VBoxContainer/HSplitContainer/RecentPanel/RecentVBox/RecentItemList")
+desc_panel = NodePath("VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel")
+desc_panel_style = SubResource("StyleBoxFlat_3qifl")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
+[node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=1385009584]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -23,21 +35,22 @@ offset_bottom = -4.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="SearchBox" type="LineEdit" parent="VBoxContainer"]
+[node name="SearchBox" type="LineEdit" parent="VBoxContainer" unique_id=879787418]
 layout_mode = 2
 placeholder_text = "Search..."
 
-[node name="HSplitContainer" type="HSplitContainer" parent="VBoxContainer"]
+[node name="HSplitContainer" type="HSplitContainer" parent="VBoxContainer" unique_id=1852524297]
 layout_mode = 2
 size_flags_vertical = 3
+split_offsets = PackedInt32Array(450)
 split_offset = 450
 
-[node name="RecentPanel" type="Panel" parent="VBoxContainer/HSplitContainer"]
-layout_mode = 2
+[node name="RecentPanel" type="Panel" parent="VBoxContainer/HSplitContainer" unique_id=2121936009]
 custom_minimum_size = Vector2(400, 0)
+layout_mode = 2
 
-[node name="RecentVBox" type="VBoxContainer" parent="VBoxContainer/HSplitContainer/RecentPanel"]
-anchors_preset = 15
+[node name="RecentVBox" type="VBoxContainer" parent="VBoxContainer/HSplitContainer/RecentPanel" unique_id=1445886196]
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = 4.0
@@ -47,21 +60,20 @@ offset_bottom = -4.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="RecentLabel" type="Label" parent="VBoxContainer/HSplitContainer/RecentPanel/RecentVBox"]
+[node name="RecentLabel" type="Label" parent="VBoxContainer/HSplitContainer/RecentPanel/RecentVBox" unique_id=1115850279]
 layout_mode = 2
 text = "Recent"
-theme_type_variations = ["header_small"]
 
-[node name="RecentItemList" type="ItemList" parent="VBoxContainer/HSplitContainer/RecentPanel/RecentVBox"]
+[node name="RecentItemList" type="ItemList" parent="VBoxContainer/HSplitContainer/RecentPanel/RecentVBox" unique_id=1495142577]
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="MainPanel" type="Panel" parent="VBoxContainer/HSplitContainer"]
+[node name="MainPanel" type="Panel" parent="VBoxContainer/HSplitContainer" unique_id=1132804728]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="MainVBox" type="VBoxContainer" parent="VBoxContainer/HSplitContainer/MainPanel"]
-anchors_preset = 15
+[node name="MainVBox" type="VBoxContainer" parent="VBoxContainer/HSplitContainer/MainPanel" unique_id=1107707669]
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = 4.0
@@ -71,21 +83,21 @@ offset_bottom = -4.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="AllLabel" type="Label" parent="VBoxContainer/HSplitContainer/MainPanel/MainVBox"]
+[node name="AllLabel" type="Label" parent="VBoxContainer/HSplitContainer/MainPanel/MainVBox" unique_id=1932058360]
 layout_mode = 2
 text = "All Actions"
-theme_type_variations = ["header_small"]
 
-[node name="ItemList" type="ItemList" parent="VBoxContainer/HSplitContainer/MainPanel/MainVBox"]
+[node name="ItemList" type="ItemList" parent="VBoxContainer/HSplitContainer/MainPanel/MainVBox" unique_id=576879617]
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="DescriptionPanel" type="Panel" parent="VBoxContainer/HSplitContainer/MainPanel/MainVBox"]
+[node name="DescriptionPanel" type="Panel" parent="VBoxContainer/HSplitContainer/MainPanel/MainVBox" unique_id=766773455]
+custom_minimum_size = Vector2(0, 150)
 layout_mode = 2
 size_flags_vertical = 0
-custom_minimum_size = Vector2(0, 150)
+theme_override_styles/panel = SubResource("StyleBoxFlat_fkpqk")
 
-[node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel"]
+[node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel" unique_id=1416222096]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -97,7 +109,7 @@ offset_bottom = -4.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="DescriptionLabel" type="Label" parent="VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel/ScrollContainer"]
+[node name="DescriptionLabel" type="Label" parent="VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel/ScrollContainer" unique_id=1743695977]
 layout_mode = 2
 size_flags_horizontal = 3
 autowrap_mode = 3

--- a/addons/flowkit/ui/modals/select_action_modal.tscn
+++ b/addons/flowkit/ui/modals/select_action_modal.tscn
@@ -1,9 +1,7 @@
 [gd_scene format=3 uid="uid://c7j20avh3m4rj"]
 
 [ext_resource type="Script" uid="uid://ckts6rjlmh4hr" path="res://addons/flowkit/ui/modals/select_action_modal.gd" id="1_action"]
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_3qifl"]
-bg_color = Color(0.2, 0.2, 0.2, 0.8)
+[ext_resource type="StyleBox" uid="uid://coc5tirv43fp" path="res://addons/flowkit/editor/styles/modal_desc_panel_style.tres" id="2_3qifl"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_fkpqk"]
 bg_color = Color(0.2, 0.2, 0.2, 0.8)
@@ -22,7 +20,7 @@ item_list = NodePath("VBoxContainer/HSplitContainer/MainPanel/MainVBox/ItemList"
 description_label = NodePath("VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel/ScrollContainer/DescriptionLabel")
 recent_item_list = NodePath("VBoxContainer/HSplitContainer/RecentPanel/RecentVBox/RecentItemList")
 desc_panel = NodePath("VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel")
-desc_panel_style = SubResource("StyleBoxFlat_3qifl")
+desc_panel_style = ExtResource("2_3qifl")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=1385009584]
 anchors_preset = 15

--- a/addons/flowkit/ui/modals/select_condition_modal.gd
+++ b/addons/flowkit/ui/modals/select_condition_modal.gd
@@ -39,7 +39,7 @@ func _toggle_subs(should_sub: bool):
 func _enter_tree() -> void:
 	super._enter_tree()
 	
-	if is_editor_preview:
+	if is_editor_preview or is_fully_legit:
 		return
 	
 	_recent_items_manager = FKRecentItemsManagerUi.new()

--- a/addons/flowkit/ui/modals/select_condition_modal.gd
+++ b/addons/flowkit/ui/modals/select_condition_modal.gd
@@ -80,7 +80,7 @@ func _load_available_conditions() -> void:
 	available_conditions.clear()
 	var conditions_path: String = "res://addons/flowkit/conditions"
 	_scan_directory_recursive(conditions_path)
-	print("Loaded ", available_conditions.size(), " conditions")
+	print("[FKSelectConditionModal]: Loaded ", available_conditions.size(), " conditions")
 
 
 func _scan_directory_recursive(path: String) -> void:
@@ -190,7 +190,7 @@ func _on_item_activated(index: int) -> void:
 			condition_name = condition.get_name()
 			break
 	
-	print("Condition selected: ", condition_id, " for node: ", selected_node_path)
+	print("[FKSelectConditionModal]: Condition selected: ", condition_id, " for node: ", selected_node_path)
 	_recent_items_manager.add_recent_condition(condition_id, condition_name, selected_node_class)
 	condition_selected.emit(selected_node_path, condition_id, inputs)
 	hide()
@@ -251,6 +251,6 @@ func _on_recent_item_activated(index: int) -> void:
 			condition_inputs = condition.get_inputs()
 			break
 	
-	print("Recent condition selected: ", condition_id, " for node: ", selected_node_path)
+	print("[FKSelectConditionModal]: Recent condition selected: ", condition_id, " for node: ", selected_node_path)
 	condition_selected.emit(selected_node_path, condition_id, condition_inputs)
 	hide()

--- a/addons/flowkit/ui/modals/select_condition_modal.gd
+++ b/addons/flowkit/ui/modals/select_condition_modal.gd
@@ -1,5 +1,5 @@
 @tool
-extends PopupPanel
+extends FKModalWindow
 class_name FKSelectConditionModal
 
 signal condition_selected(node_path: String, condition_id: String, condition_inputs: Array)
@@ -19,29 +19,28 @@ var _all_items_cache: Array = []
 var _recent_items_manager: Variant = null
 
 
-func _toggle_subs(on: bool):
-	if on and not _is_subbed:
+func _toggle_subs(should_sub: bool):
+	if should_sub and not _is_subbed:
 		search_box.text_changed.connect(_on_search_text_changed)
 		item_list.item_activated.connect(_on_item_activated)
 		item_list.item_selected.connect(_on_item_selected)
 		recent_item_list.item_activated.connect(_on_recent_item_activated)
-	elif _is_subbed and !on:
+	elif _is_subbed and !should_sub:
 		search_box.text_changed.disconnect(_on_search_text_changed)
 		item_list.item_activated.disconnect(_on_item_activated)
 		item_list.item_selected.disconnect(_on_item_selected)
 		recent_item_list.item_activated.disconnect(_on_recent_item_activated)
-		
-	_is_subbed = on
-	
-var _is_subbed := false
-
-func _enter_tree() -> void:
-	if is_editor_preview:
+	else:
 		return
 		
-	_ensure_export_fields_filled()
-	_set_desc_panel_style()
-	_toggle_subs(true)
+	_is_subbed = should_sub
+	
+
+func _enter_tree() -> void:
+	super._enter_tree()
+	
+	if is_editor_preview:
+		return
 	
 	_recent_items_manager = FKRecentItemsManagerUi.new()
 	_load_available_conditions()
@@ -75,17 +74,6 @@ func _set_desc_panel_style():
 		desc_panel_style.bg_color = Color(0.2, 0.2, 0.2, 0.8)
 	desc_panel.add_theme_stylebox_override("panel", desc_panel_style)
 	
-func legitimize():
-	if not is_editor_preview:
-		return
-	_is_editor_preview = false
-	_enter_tree()
-
-var is_editor_preview: bool:
-	get:
-		return _is_editor_preview
-		
-var _is_editor_preview := true
 
 func _load_available_conditions() -> void:
 	"""Load all condition scripts from the conditions folder."""
@@ -94,15 +82,6 @@ func _load_available_conditions() -> void:
 	_scan_directory_recursive(conditions_path)
 	print("Loaded ", available_conditions.size(), " conditions")
 
-func set_editor_interface(interface: EditorInterface) -> void:
-	editor_interface = interface
-		
-var editor_interface: EditorInterface
-
-func set_registry(reg: FKRegistry):
-	registry = reg
-	
-var registry: FKRegistry
 
 func _scan_directory_recursive(path: String) -> void:
 	"""Recursively scan directories for condition scripts."""
@@ -232,8 +211,7 @@ func _on_item_selected(index: int) -> void:
 			break
 
 func _on_popup_hide() -> void:
-	if search_box:
-		search_box.clear()
+	search_box.clear()
 
 func _populate_recent_list() -> void:
 	"""Populate the recent conditions list."""

--- a/addons/flowkit/ui/modals/select_condition_modal.gd
+++ b/addons/flowkit/ui/modals/select_condition_modal.gd
@@ -8,36 +8,84 @@ var selected_node_path: String = ""
 var selected_node_class: String = ""
 var available_conditions: Array = []
 
-@onready var search_box := $VBoxContainer/SearchBox
-@onready var item_list := $VBoxContainer/HSplitContainer/MainPanel/MainVBox/ItemList
-@onready var description_label := $VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel/ScrollContainer/DescriptionLabel
-@onready var recent_item_list := $VBoxContainer/HSplitContainer/RecentPanel/RecentVBox/RecentItemList
+@export var search_box: LineEdit
+@export var item_list: ItemList
+@export var description_label: Label
+@export var recent_item_list: ItemList
+@export var desc_panel: Panel
+@export var desc_panel_style: StyleBoxFlat
 
 var _all_items_cache: Array = []
 var _recent_items_manager: Variant = null
 
-func _ready() -> void:
-	if search_box:
+
+func _toggle_subs(on: bool):
+	if on and not _is_subbed:
 		search_box.text_changed.connect(_on_search_text_changed)
-		
-	if item_list:
 		item_list.item_activated.connect(_on_item_activated)
 		item_list.item_selected.connect(_on_item_selected)
-	
-	if recent_item_list:
 		recent_item_list.item_activated.connect(_on_recent_item_activated)
+	elif _is_subbed and !on:
+		search_box.text_changed.disconnect(_on_search_text_changed)
+		item_list.item_activated.disconnect(_on_item_activated)
+		item_list.item_selected.disconnect(_on_item_selected)
+		recent_item_list.item_activated.disconnect(_on_recent_item_activated)
+		
+	_is_subbed = on
 	
-	# Set description panel style
-	var panel = $VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel
-	var style = StyleBoxFlat.new()
-	style.bg_color = Color(0.2, 0.2, 0.2, 0.8)
-	panel.add_theme_stylebox_override("panel", style)
+var _is_subbed := false
+
+func _enter_tree() -> void:
+	if is_editor_preview:
+		return
+		
+	_ensure_export_fields_filled()
+	_set_desc_panel_style()
+	_toggle_subs(true)
 	
-	# Load recent items manager
-	_recent_items_manager = load("res://addons/flowkit/ui/modals/recent_items_manager.gd").new()
-	
-	# Load all available conditions
+	_recent_items_manager = FKRecentItemsManagerUi.new()
 	_load_available_conditions()
+
+func _ensure_export_fields_filled():
+	var path: String
+	if not search_box:
+		path = "VBoxContainer/SearchBox"
+		search_box = get_node(path)
+	
+	if not item_list:
+		path = "VBoxContainer/HSplitContainer/MainPanel/MainVBox/ItemList"
+		item_list = get_node(path)
+		
+	if not description_label:
+		path = "VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel/" +\
+		"ScrollContainer/DescriptionLabel"
+		description_label = get_node(path)
+		
+	if not recent_item_list:
+		path = "VBoxContainer/HSplitContainer/RecentPanel/RecentVBox/RecentItemList"
+		recent_item_list = get_node(path)
+		
+	if not desc_panel:
+		path = "VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel"
+		desc_panel = get_node(path)
+			
+func _set_desc_panel_style():
+	if not desc_panel_style:
+		desc_panel_style = StyleBoxFlat.new()
+		desc_panel_style.bg_color = Color(0.2, 0.2, 0.2, 0.8)
+	desc_panel.add_theme_stylebox_override("panel", desc_panel_style)
+	
+func legitimize():
+	if not is_editor_preview:
+		return
+	_is_editor_preview = false
+	_enter_tree()
+
+var is_editor_preview: bool:
+	get:
+		return _is_editor_preview
+		
+var _is_editor_preview := true
 
 func _load_available_conditions() -> void:
 	"""Load all condition scripts from the conditions folder."""

--- a/addons/flowkit/ui/modals/select_condition_modal.tscn
+++ b/addons/flowkit/ui/modals/select_condition_modal.tscn
@@ -1,16 +1,24 @@
 [gd_scene format=3 uid="uid://cam4a1xj6n7ql"]
 
 [ext_resource type="Script" uid="uid://bn7bags6twbx0" path="res://addons/flowkit/ui/modals/select_condition_modal.gd" id="1_condition"]
+[ext_resource type="StyleBox" uid="uid://coc5tirv43fp" path="res://addons/flowkit/editor/styles/modal_desc_panel_style.tres" id="2_ftt57"]
 
-[node name="SelectCondition" type="PopupPanel" unique_id=1328454773]
+[node name="SelectCondition" type="PopupPanel" unique_id=1328454773 node_paths=PackedStringArray("search_box", "item_list", "description_label", "recent_item_list", "desc_panel")]
 oversampling_override = 1.0
 title = "Select a Condition"
+position = Vector2i(0, 36)
 size = Vector2i(900, 600)
 visible = true
 unresizable = false
 borderless = false
 keep_title_visible = true
 script = ExtResource("1_condition")
+search_box = NodePath("VBoxContainer/SearchBox")
+item_list = NodePath("VBoxContainer/HSplitContainer/MainPanel/MainVBox/ItemList")
+description_label = NodePath("VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel/ScrollContainer/DescriptionLabel")
+recent_item_list = NodePath("VBoxContainer/HSplitContainer/RecentPanel/RecentVBox/RecentItemList")
+desc_panel = NodePath("VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel")
+desc_panel_style = ExtResource("2_ftt57")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=1218923047]
 anchors_preset = 15

--- a/addons/flowkit/ui/modals/select_condition_modal.tscn
+++ b/addons/flowkit/ui/modals/select_condition_modal.tscn
@@ -2,17 +2,17 @@
 
 [ext_resource type="Script" uid="uid://bn7bags6twbx0" path="res://addons/flowkit/ui/modals/select_condition_modal.gd" id="1_condition"]
 
-[node name="SelectCondition" type="PopupPanel"]
+[node name="SelectCondition" type="PopupPanel" unique_id=1328454773]
 oversampling_override = 1.0
 title = "Select a Condition"
-initial_position = 0
 size = Vector2i(900, 600)
+visible = true
+unresizable = false
 borderless = false
 keep_title_visible = true
-unresizable = false
 script = ExtResource("1_condition")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
+[node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=1218923047]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -23,21 +23,22 @@ offset_bottom = -4.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="SearchBox" type="LineEdit" parent="VBoxContainer"]
+[node name="SearchBox" type="LineEdit" parent="VBoxContainer" unique_id=376539148]
 layout_mode = 2
 placeholder_text = "Search..."
 
-[node name="HSplitContainer" type="HSplitContainer" parent="VBoxContainer"]
+[node name="HSplitContainer" type="HSplitContainer" parent="VBoxContainer" unique_id=1592481814]
 layout_mode = 2
 size_flags_vertical = 3
+split_offsets = PackedInt32Array(450)
 split_offset = 450
 
-[node name="RecentPanel" type="Panel" parent="VBoxContainer/HSplitContainer"]
-layout_mode = 2
+[node name="RecentPanel" type="Panel" parent="VBoxContainer/HSplitContainer" unique_id=1575374208]
 custom_minimum_size = Vector2(400, 0)
+layout_mode = 2
 
-[node name="RecentVBox" type="VBoxContainer" parent="VBoxContainer/HSplitContainer/RecentPanel"]
-anchors_preset = 15
+[node name="RecentVBox" type="VBoxContainer" parent="VBoxContainer/HSplitContainer/RecentPanel" unique_id=802680281]
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = 4.0
@@ -47,21 +48,20 @@ offset_bottom = -4.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="RecentLabel" type="Label" parent="VBoxContainer/HSplitContainer/RecentPanel/RecentVBox"]
+[node name="RecentLabel" type="Label" parent="VBoxContainer/HSplitContainer/RecentPanel/RecentVBox" unique_id=889454355]
 layout_mode = 2
 text = "Recent"
-theme_type_variations = ["header_small"]
 
-[node name="RecentItemList" type="ItemList" parent="VBoxContainer/HSplitContainer/RecentPanel/RecentVBox"]
+[node name="RecentItemList" type="ItemList" parent="VBoxContainer/HSplitContainer/RecentPanel/RecentVBox" unique_id=1854709250]
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="MainPanel" type="Panel" parent="VBoxContainer/HSplitContainer"]
+[node name="MainPanel" type="Panel" parent="VBoxContainer/HSplitContainer" unique_id=368839918]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="MainVBox" type="VBoxContainer" parent="VBoxContainer/HSplitContainer/MainPanel"]
-anchors_preset = 15
+[node name="MainVBox" type="VBoxContainer" parent="VBoxContainer/HSplitContainer/MainPanel" unique_id=1073361098]
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = 4.0
@@ -71,21 +71,20 @@ offset_bottom = -4.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="AllLabel" type="Label" parent="VBoxContainer/HSplitContainer/MainPanel/MainVBox"]
+[node name="AllLabel" type="Label" parent="VBoxContainer/HSplitContainer/MainPanel/MainVBox" unique_id=2070823011]
 layout_mode = 2
 text = "All Conditions"
-theme_type_variations = ["header_small"]
 
-[node name="ItemList" type="ItemList" parent="VBoxContainer/HSplitContainer/MainPanel/MainVBox"]
+[node name="ItemList" type="ItemList" parent="VBoxContainer/HSplitContainer/MainPanel/MainVBox" unique_id=34358662]
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="DescriptionPanel" type="Panel" parent="VBoxContainer/HSplitContainer/MainPanel/MainVBox"]
+[node name="DescriptionPanel" type="Panel" parent="VBoxContainer/HSplitContainer/MainPanel/MainVBox" unique_id=61533282]
+custom_minimum_size = Vector2(0, 150)
 layout_mode = 2
 size_flags_vertical = 0
-custom_minimum_size = Vector2(0, 150)
 
-[node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel"]
+[node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel" unique_id=1534101736]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -97,7 +96,7 @@ offset_bottom = -4.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="DescriptionLabel" type="Label" parent="VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel/ScrollContainer"]
+[node name="DescriptionLabel" type="Label" parent="VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel/ScrollContainer" unique_id=268459902]
 layout_mode = 2
 size_flags_horizontal = 3
 autowrap_mode = 3

--- a/addons/flowkit/ui/modals/select_event_modal.gd
+++ b/addons/flowkit/ui/modals/select_event_modal.gd
@@ -8,10 +8,25 @@ var selected_node_path: String = ""
 var selected_node_class: String = ""
 var available_events: Array = []
 
-@onready var search_box := $VBoxContainer/SearchBox
-@onready var item_list := $VBoxContainer/HSplitContainer/MainPanel/MainVBox/ItemList
-@onready var description_label := $VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel/ScrollContainer/DescriptionLabel
-@onready var recent_item_list := $VBoxContainer/HSplitContainer/RecentPanel/RecentVBox/RecentItemList
+@export var search_box: LineEdit 
+@export var item_list: ItemList 
+@export var description_label: Label 
+@export var recent_item_list: ItemList 
+@export var desc_panel: Panel
+
+@export var desc_panel_style: StyleBoxFlat
+
+func legitimize():
+	if not is_editor_preview:
+		return
+	_is_editor_preview = false
+	_enter_tree()
+
+var is_editor_preview: bool:
+	get:
+		return _is_editor_preview
+		
+var _is_editor_preview := true
 
 var _all_items_cache: Array = []
 var _recent_items_manager: Variant = null
@@ -26,33 +41,67 @@ func set_registry(reg: FKRegistry):
 	
 var registry: FKRegistry
 
-func _ready() -> void:
-	if search_box:
-		search_box.text_changed.connect(_on_search_text_changed)
+func _enter_tree() -> void:
+	if is_editor_preview:
+		return
 		
-	if item_list:
+	_ensure_export_fields_filled()
+	_set_desc_panel_style()
+	_toggle_subs(true)
+	_recent_items_manager = FKRecentItemsManagerUi.new()
+	_load_available_events()
+
+func _ensure_export_fields_filled():
+	var path: String
+	if not search_box:
+		path = "VBoxContainer/SearchBox"
+		search_box = get_node(path)
+		
+	if not item_list:
+		path = "VBoxContainer/HSplitContainer/MainPanel/MainVBox/ItemList"
+		item_list = get_node(path)
+		
+	if not description_label:
+		path = "VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel/" +\
+		"ScrollContainer/DescriptionLabel"
+		description_label = get_node(path)
+	
+	if not recent_item_list:
+		path = "VBoxContainer/HSplitContainer/RecentPanel/RecentVBox/RecentItemList"
+		recent_item_list = get_node(path)
+		
+	if not desc_panel:
+		path = "VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel"
+		desc_panel = get_node(path)
+		
+func _set_desc_panel_style():
+	if is_editor_preview:
+		return
+		
+	desc_panel.add_theme_stylebox_override("panel", desc_panel_style)
+		
+func _toggle_subs(on: bool):
+	if on and not _is_subbed:
+		search_box.text_changed.connect(_on_search_text_changed)
 		item_list.item_activated.connect(_on_item_activated)
 		item_list.item_selected.connect(_on_item_selected)
-	
-	if recent_item_list:
 		recent_item_list.item_activated.connect(_on_recent_item_activated)
+	elif _is_subbed and !on:
+		search_box.text_changed.disconnect(_on_search_text_changed)
+		item_list.item_activated.disconnect(_on_item_activated)
+		item_list.item_selected.disconnect(_on_item_selected)
+		recent_item_list.item_activated.disconnect(_on_recent_item_activated)
+	else:
+		return
+		
+	_is_subbed = on
 	
-	# Set description panel style
-	var panel = $VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel
-	var style = StyleBoxFlat.new()
-	style.bg_color = Color(0.2, 0.2, 0.2, 0.8)
-	panel.add_theme_stylebox_override("panel", style)
-	
-	# Load recent items manager
-	_recent_items_manager = load("res://addons/flowkit/ui/modals/recent_items_manager.gd").new()
-	
-	# Load all available events
-	_load_available_events()
+var _is_subbed := false
 
 func _load_available_events() -> void:
 	"""Load all event scripts from the events folder."""
 	available_events.clear()
-	var events_path: String = "res://addons/flowkit/events"
+	var events_path: String = FKEditorGlobals.PATH_TO_EVENTS_FOLDER
 	_scan_directory_recursive(events_path)
 	print("Loaded ", available_events.size(), " events")
 
@@ -243,3 +292,9 @@ func _on_recent_item_activated(index: int) -> void:
 	print("Recent event selected: ", event_id, " for node: ", selected_node_path)
 	event_selected.emit(selected_node_path, event_id, event_inputs)
 	hide()
+
+func _exit_tree() -> void:
+	if is_editor_preview:
+		return
+		
+	_toggle_subs(false)

--- a/addons/flowkit/ui/modals/select_event_modal.gd
+++ b/addons/flowkit/ui/modals/select_event_modal.gd
@@ -1,5 +1,5 @@
 @tool
-extends PopupPanel
+extends FKModalWindow
 class_name FKSelectEventModal
 
 signal event_selected(node_path: String, event_id: String, event_inputs: Array)
@@ -16,40 +16,19 @@ var available_events: Array = []
 
 @export var desc_panel_style: StyleBoxFlat
 
-func legitimize():
-	if not is_editor_preview:
-		return
-	_is_editor_preview = false
-	_enter_tree()
-
-var is_editor_preview: bool:
-	get:
-		return _is_editor_preview
-		
-var _is_editor_preview := true
-
 var _all_items_cache: Array = []
-var _recent_items_manager: Variant = null
 
-func set_editor_interface(interface: EditorInterface) -> void:
-	editor_interface = interface
-
-var editor_interface: EditorInterface
-
-func set_registry(reg: FKRegistry):
-	registry = reg
-	
-var registry: FKRegistry
 
 func _enter_tree() -> void:
+	super._enter_tree()
+	
 	if is_editor_preview:
 		return
 		
-	_ensure_export_fields_filled()
-	_set_desc_panel_style()
-	_toggle_subs(true)
 	_recent_items_manager = FKRecentItemsManagerUi.new()
 	_load_available_events()
+
+var _recent_items_manager: Variant = null
 
 func _ensure_export_fields_filled():
 	var path: String
@@ -74,10 +53,7 @@ func _ensure_export_fields_filled():
 		path = "VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel"
 		desc_panel = get_node(path)
 		
-func _set_desc_panel_style():
-	if is_editor_preview:
-		return
-		
+func _apply_styling():
 	desc_panel.add_theme_stylebox_override("panel", desc_panel_style)
 		
 func _toggle_subs(on: bool):
@@ -96,8 +72,6 @@ func _toggle_subs(on: bool):
 		
 	_is_subbed = on
 	
-var _is_subbed := false
-
 func _load_available_events() -> void:
 	"""Load all event scripts from the events folder."""
 	available_events.clear()
@@ -292,9 +266,3 @@ func _on_recent_item_activated(index: int) -> void:
 	print("Recent event selected: ", event_id, " for node: ", selected_node_path)
 	event_selected.emit(selected_node_path, event_id, event_inputs)
 	hide()
-
-func _exit_tree() -> void:
-	if is_editor_preview:
-		return
-		
-	_toggle_subs(false)

--- a/addons/flowkit/ui/modals/select_event_modal.gd
+++ b/addons/flowkit/ui/modals/select_event_modal.gd
@@ -77,7 +77,7 @@ func _load_available_events() -> void:
 	available_events.clear()
 	var events_path: String = FKEditorGlobals.PATH_TO_EVENTS_FOLDER
 	_scan_directory_recursive(events_path)
-	print("Loaded ", available_events.size(), " events")
+	print("[FKSelectEventModal]: Loaded ", available_events.size(), " events")
 
 func _scan_directory_recursive(path: String) -> void:
 	"""Recursively scan directories for event scripts."""
@@ -201,7 +201,7 @@ func _on_item_activated(index: int) -> void:
 				event_name = event.get_name()
 			break
 	
-	print("Event selected: ", event_id, " for node: ", selected_node_path, " with inputs: ", event_inputs)
+	print("[FKSelectEventModal]: Event selected: ", event_id, " for node: ", selected_node_path, " with inputs: ", event_inputs)
 	_recent_items_manager.add_recent_event(event_id, event_name, selected_node_class)
 	event_selected.emit(selected_node_path, event_id, event_inputs)
 	hide()
@@ -263,6 +263,6 @@ func _on_recent_item_activated(index: int) -> void:
 				event_inputs = event.get_inputs()
 			break
 	
-	print("Recent event selected: ", event_id, " for node: ", selected_node_path)
+	print("[FKSelectEventModal]: Recent event selected: ", event_id, " for node: ", selected_node_path)
 	event_selected.emit(selected_node_path, event_id, event_inputs)
 	hide()

--- a/addons/flowkit/ui/modals/select_event_modal.gd
+++ b/addons/flowkit/ui/modals/select_event_modal.gd
@@ -8,21 +8,22 @@ var selected_node_path: String = ""
 var selected_node_class: String = ""
 var available_events: Array = []
 
+@export_category("UI")
 @export var search_box: LineEdit 
 @export var item_list: ItemList 
 @export var description_label: Label 
 @export var recent_item_list: ItemList 
 @export var desc_panel: Panel
 
+@export_category("Styling")
 @export var desc_panel_style: StyleBoxFlat
 
 var _all_items_cache: Array = []
 
-
 func _enter_tree() -> void:
 	super._enter_tree()
 	
-	if is_editor_preview:
+	if is_editor_preview or is_fully_legit:
 		return
 		
 	_recent_items_manager = FKRecentItemsManagerUi.new()

--- a/addons/flowkit/ui/modals/select_event_modal.tscn
+++ b/addons/flowkit/ui/modals/select_event_modal.tscn
@@ -1,9 +1,7 @@
 [gd_scene format=3 uid="uid://crj5y8vh2m3qi"]
 
 [ext_resource type="Script" uid="uid://dcajc4erjcorh" path="res://addons/flowkit/ui/modals/select_event_modal.gd" id="1_event"]
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_vx0pf"]
-bg_color = Color(0.2, 0.2, 0.2, 0.8)
+[ext_resource type="StyleBox" uid="uid://coc5tirv43fp" path="res://addons/flowkit/editor/styles/modal_desc_panel_style.tres" id="2_vx0pf"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_p4fh0"]
 bg_color = Color(0.2, 0.2, 0.2, 0.8)
@@ -23,7 +21,7 @@ item_list = NodePath("VBoxContainer/HSplitContainer/MainPanel/MainVBox/ItemList"
 description_label = NodePath("VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel/ScrollContainer/DescriptionLabel")
 recent_item_list = NodePath("VBoxContainer/HSplitContainer/RecentPanel/RecentVBox/RecentItemList")
 desc_panel = NodePath("VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel")
-desc_panel_style = SubResource("StyleBoxFlat_vx0pf")
+desc_panel_style = ExtResource("2_vx0pf")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=847659102]
 anchors_preset = 15

--- a/addons/flowkit/ui/modals/select_event_modal.tscn
+++ b/addons/flowkit/ui/modals/select_event_modal.tscn
@@ -3,9 +3,6 @@
 [ext_resource type="Script" uid="uid://dcajc4erjcorh" path="res://addons/flowkit/ui/modals/select_event_modal.gd" id="1_event"]
 [ext_resource type="StyleBox" uid="uid://coc5tirv43fp" path="res://addons/flowkit/editor/styles/modal_desc_panel_style.tres" id="2_vx0pf"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_p4fh0"]
-bg_color = Color(0.2, 0.2, 0.2, 0.8)
-
 [node name="SelectEvent" type="PopupPanel" unique_id=484748214 node_paths=PackedStringArray("search_box", "item_list", "description_label", "recent_item_list", "desc_panel")]
 oversampling_override = 1.0
 title = "Select an Event"
@@ -94,7 +91,7 @@ size_flags_vertical = 3
 custom_minimum_size = Vector2(0, 150)
 layout_mode = 2
 size_flags_vertical = 0
-theme_override_styles/panel = SubResource("StyleBoxFlat_p4fh0")
+theme_override_styles/panel = ExtResource("2_vx0pf")
 
 [node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel" unique_id=585313885]
 layout_mode = 1

--- a/addons/flowkit/ui/modals/select_event_modal.tscn
+++ b/addons/flowkit/ui/modals/select_event_modal.tscn
@@ -2,10 +2,13 @@
 
 [ext_resource type="Script" uid="uid://dcajc4erjcorh" path="res://addons/flowkit/ui/modals/select_event_modal.gd" id="1_event"]
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_vx0pf"]
+bg_color = Color(0.2, 0.2, 0.2, 0.8)
+
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_p4fh0"]
 bg_color = Color(0.2, 0.2, 0.2, 0.8)
 
-[node name="SelectEvent" type="PopupPanel" unique_id=484748214]
+[node name="SelectEvent" type="PopupPanel" unique_id=484748214 node_paths=PackedStringArray("search_box", "item_list", "description_label", "recent_item_list", "desc_panel")]
 oversampling_override = 1.0
 title = "Select an Event"
 position = Vector2i(0, 36)
@@ -15,6 +18,12 @@ unresizable = false
 borderless = false
 keep_title_visible = true
 script = ExtResource("1_event")
+search_box = NodePath("VBoxContainer/SearchBox")
+item_list = NodePath("VBoxContainer/HSplitContainer/MainPanel/MainVBox/ItemList")
+description_label = NodePath("VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel/ScrollContainer/DescriptionLabel")
+recent_item_list = NodePath("VBoxContainer/HSplitContainer/RecentPanel/RecentVBox/RecentItemList")
+desc_panel = NodePath("VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel")
+desc_panel_style = SubResource("StyleBoxFlat_vx0pf")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=847659102]
 anchors_preset = 15

--- a/addons/flowkit/ui/modals/select_node_modal.gd
+++ b/addons/flowkit/ui/modals/select_node_modal.gd
@@ -106,8 +106,8 @@ func populate_from_scene(scene_root: Node) -> void:
 	
 	# Add System option at the top
 	var system_icon = null
-	if editor_interface:
-		system_icon = editor_interface.get_base_control().get_theme_icon("Node", "EditorIcons")
+	if _editor_interface:
+		system_icon = _editor_interface.get_base_control().get_theme_icon("Node", "EditorIcons")
 		
 	_all_items_cache.append({
 		"display_name": "System",
@@ -135,8 +135,8 @@ func _add_node_recursive(node: Node, scene_root: Node, depth: int) -> void:
 	var has_compatible_event = _has_compatible_event(node_class)
 	
 	var icon = null
-	if editor_interface:
-		icon = editor_interface.get_base_control().get_theme_icon(node.get_class(), "EditorIcons")
+	if _editor_interface:
+		icon = _editor_interface.get_base_control().get_theme_icon(node.get_class(), "EditorIcons")
 	
 	_all_items_cache.append({
 		"display_name": node_name,
@@ -237,10 +237,10 @@ func _on_item_activated(index: int) -> void:
 
 func _get_node_from_path(node_path_str: String) -> Node:
 	"""Get the actual node from the scene by path."""
-	if not editor_interface:
+	if not _editor_interface:
 		return null
 	
-	var current_scene = editor_interface.get_edited_scene_root()
+	var current_scene = _editor_interface.get_edited_scene_root()
 	if not current_scene:
 		return null
 	

--- a/addons/flowkit/ui/modals/select_node_modal.gd
+++ b/addons/flowkit/ui/modals/select_node_modal.gd
@@ -7,36 +7,61 @@ signal node_selected(node_path: String, node_class: String)
 var editor_interface: EditorInterface
 var available_events: Array = []
 
-@onready var search_box := $VBoxContainer/SearchBox
-@onready var item_list := $VBoxContainer/HSplitContainer/MainPanel/MainVBox/ItemList
-@onready var recent_item_list := $VBoxContainer/HSplitContainer/RecentPanel/RecentVBox/RecentItemList
+@export var search_box: LineEdit  
+@export var item_list: ItemList
+@export var recent_item_list: ItemList
 
 var _all_items_cache: Array = []
 var _recent_items_manager: Variant = null
 
-func _ready() -> void:
-	if search_box:
-		search_box.text_changed.connect(_on_search_text_changed)
+func legitimize():
+	if not is_editor_preview:
+		return
+	_is_editor_preview = false
+	_enter_tree()
+	_ready()
+
+var is_editor_preview: bool:
+	get:
+		return _is_editor_preview
 		
-	if item_list:
+var _is_editor_preview := true
+
+func _enter_tree() -> void:
+	if is_editor_preview:
+		return
+		
+	_toggle_subs(true)
+	_recent_items_manager = FKRecentItemsManagerUi.new()
+	
+func _toggle_subs(on: bool):
+	if on and not _is_subbed:
+		search_box.text_changed.connect(_on_search_text_changed)
 		item_list.item_activated.connect(_on_item_activated)
 		item_list.item_selected.connect(_on_item_selected)
-	
-	if recent_item_list:
 		recent_item_list.item_activated.connect(_on_recent_item_activated)
-	
-	# Load recent items manager
-	_recent_items_manager = load("res://addons/flowkit/ui/modals/recent_items_manager.gd").new()
-	
+	elif _is_subbed and !on:
+		search_box.text_changed.disconnect(_on_search_text_changed)
+		item_list.item_activated.disconnect(_on_item_activated)
+		item_list.item_selected.disconnect(_on_item_selected)
+		recent_item_list.item_activated.disconnect(_on_recent_item_activated)
+	else:
+		return
+		
+	_is_subbed = on
+
+var _is_subbed := false
+func _ready() -> void:
 	# Load all available events to check compatibility
-	_load_available_events()
+	_load_available_event_scripts()
 	_populate_recent_list()
 
-func _load_available_events() -> void:
+func _load_available_event_scripts() -> void:
 	"""Load all event scripts from the events folder."""
 	available_events.clear()
-	var events_path: String = "res://addons/flowkit/events"
-	_scan_directory_recursive(events_path)
+	_scan_directory_recursive(_path_to_events_folder)
+
+static var _path_to_events_folder := "res://addons/flowkit/events"
 
 func _scan_directory_recursive(path: String) -> void:
 	"""Recursively scan directories for event scripts."""
@@ -49,11 +74,12 @@ func _scan_directory_recursive(path: String) -> void:
 	
 	while file_name != "":
 		var full_path: String = path + "/" + file_name
+		var is_subdir: bool = dir.current_is_dir() and not file_name.begins_with(".")
+		var is_event_script: bool = file_name.ends_with(".gd") and not file_name.ends_with(".gd.uid")
 		
-		if dir.current_is_dir() and not file_name.begins_with("."):
-			# Recursively scan subdirectory
+		if is_subdir:
 			_scan_directory_recursive(full_path)
-		elif file_name.ends_with(".gd") and not file_name.ends_with(".gd.uid"):
+		elif is_event_script:
 			var event_script: Variant = load(full_path)
 			if event_script:
 				var event_instance: Variant = event_script.new()
@@ -63,6 +89,27 @@ func _scan_directory_recursive(path: String) -> void:
 	
 	dir.list_dir_end()
 
+func _populate_recent_list() -> void:
+	"""Populate the recent items list."""
+	if not _recent_items_manager:
+		return
+	
+	recent_item_list.clear()
+	
+	if _recent_items_manager.recent_nodes.is_empty():
+		recent_item_list.add_item("(No recent items)")
+		recent_item_list.set_item_disabled(0, true)
+		return
+	
+	for recent_node in _recent_items_manager.recent_nodes:
+		var display_name = recent_node["path"]
+		if recent_node["path"] == "System":
+			display_name = "System"
+		
+		recent_item_list.add_item(display_name)
+		var index = recent_item_list.item_count - 1
+		recent_item_list.set_item_metadata(index, recent_node)
+		
 func set_editor_interface(interface: EditorInterface):
 	editor_interface = interface
 
@@ -230,27 +277,6 @@ func _on_popup_hide() -> void:
 	if search_box:
 		search_box.clear()
 
-func _populate_recent_list() -> void:
-	"""Populate the recent items list."""
-	if not recent_item_list or not _recent_items_manager:
-		return
-	
-	recent_item_list.clear()
-	
-	if _recent_items_manager.recent_nodes.is_empty():
-		recent_item_list.add_item("(No recent items)")
-		recent_item_list.set_item_disabled(0, true)
-		return
-	
-	for recent_node in _recent_items_manager.recent_nodes:
-		var display_name = recent_node["path"]
-		if recent_node["path"] == "System":
-			display_name = "System"
-		
-		recent_item_list.add_item(display_name)
-		var index = recent_item_list.item_count - 1
-		recent_item_list.set_item_metadata(index, recent_node)
-
 func _on_recent_item_activated(index: int) -> void:
 	"""Handle selection from recent items."""
 	if recent_item_list.is_item_disabled(index):
@@ -263,3 +289,9 @@ func _on_recent_item_activated(index: int) -> void:
 	print("Recent node selected: ", node_path_str, " (", node_class, ")")
 	node_selected.emit(node_path_str, node_class)
 	hide()
+
+func _exit_tree() -> void:
+	if is_editor_preview:
+		return
+		
+	_toggle_subs(false)

--- a/addons/flowkit/ui/modals/select_node_modal.gd
+++ b/addons/flowkit/ui/modals/select_node_modal.gd
@@ -136,7 +136,8 @@ func _add_node_recursive(node: Node, scene_root: Node, depth: int) -> void:
 	
 	var icon = null
 	if _editor_interface:
-		icon = _editor_interface.get_base_control().get_theme_icon(node.get_class(), "EditorIcons")
+		var base_control := _editor_interface.get_base_control()
+		icon = base_control.get_theme_icon(node_class, "EditorIcons")
 	
 	_all_items_cache.append({
 		"display_name": node_name,
@@ -221,7 +222,7 @@ func _on_item_activated(index: int) -> void:
 	
 	# Handle System node
 	if node_path_str == "System":
-		print("Node selected: System (System)")
+		print("[FKSelectNodeModal]: Node selected: System (System)")
 		_recent_items_manager.add_recent_node("System", "System")
 		node_selected.emit("System", "System")
 		hide()
@@ -230,7 +231,7 @@ func _on_item_activated(index: int) -> void:
 	var node = _get_node_from_path(node_path_str)
 	if node:
 		var node_class = node.get_class()
-		print("Node selected: ", node_path_str, " (", node_class, ")")
+		print("[FKSelectNodeModal]: Node selected: ", node_path_str, " (", node_class, ")")
 		_recent_items_manager.add_recent_node(node_path_str, node_class)
 		node_selected.emit(node_path_str, node_class)
 		hide()
@@ -266,6 +267,6 @@ func _on_recent_item_activated(index: int) -> void:
 	var node_path_str = recent_node["path"]
 	var node_class = recent_node["class"]
 	
-	print("Recent node selected: ", node_path_str, " (", node_class, ")")
+	print("[FKSelectNodeModal]: Recent node selected: ", node_path_str, " (", node_class, ")")
 	node_selected.emit(node_path_str, node_class)
 	hide()

--- a/addons/flowkit/ui/modals/select_node_modal.gd
+++ b/addons/flowkit/ui/modals/select_node_modal.gd
@@ -1,10 +1,9 @@
 @tool
-extends PopupPanel
+extends FKModalWindow
 class_name FKSelectNodeModal
 
 signal node_selected(node_path: String, node_class: String)
 
-var editor_interface: EditorInterface
 var available_events: Array = []
 
 @export var search_box: LineEdit  
@@ -12,35 +11,24 @@ var available_events: Array = []
 @export var recent_item_list: ItemList
 
 var _all_items_cache: Array = []
-var _recent_items_manager: Variant = null
-
-func legitimize():
-	if not is_editor_preview:
-		return
-	_is_editor_preview = false
-	_enter_tree()
-	_ready()
-
-var is_editor_preview: bool:
-	get:
-		return _is_editor_preview
-		
-var _is_editor_preview := true
 
 func _enter_tree() -> void:
+	super._enter_tree()
+	
 	if is_editor_preview:
 		return
 		
-	_toggle_subs(true)
 	_recent_items_manager = FKRecentItemsManagerUi.new()
 	
-func _toggle_subs(on: bool):
-	if on and not _is_subbed:
+var _recent_items_manager: Variant = null
+	
+func _toggle_subs(should_sub: bool):
+	if should_sub and not _is_subbed:
 		search_box.text_changed.connect(_on_search_text_changed)
 		item_list.item_activated.connect(_on_item_activated)
 		item_list.item_selected.connect(_on_item_selected)
 		recent_item_list.item_activated.connect(_on_recent_item_activated)
-	elif _is_subbed and !on:
+	elif _is_subbed and not should_sub:
 		search_box.text_changed.disconnect(_on_search_text_changed)
 		item_list.item_activated.disconnect(_on_item_activated)
 		item_list.item_selected.disconnect(_on_item_selected)
@@ -48,10 +36,11 @@ func _toggle_subs(on: bool):
 	else:
 		return
 		
-	_is_subbed = on
+	_is_subbed = should_sub
 
-var _is_subbed := false
 func _ready() -> void:
+	if is_editor_preview:
+		return
 	# Load all available events to check compatibility
 	_load_available_event_scripts()
 	_populate_recent_list()
@@ -59,9 +48,8 @@ func _ready() -> void:
 func _load_available_event_scripts() -> void:
 	"""Load all event scripts from the events folder."""
 	available_events.clear()
-	_scan_directory_recursive(_path_to_events_folder)
-
-static var _path_to_events_folder := "res://addons/flowkit/events"
+	var path := FKEditorGlobals.PATH_TO_EVENTS_FOLDER
+	_scan_directory_recursive(path)
 
 func _scan_directory_recursive(path: String) -> void:
 	"""Recursively scan directories for event scripts."""
@@ -109,14 +97,6 @@ func _populate_recent_list() -> void:
 		recent_item_list.add_item(display_name)
 		var index = recent_item_list.item_count - 1
 		recent_item_list.set_item_metadata(index, recent_node)
-		
-func set_editor_interface(interface: EditorInterface):
-	editor_interface = interface
-
-func set_registry(reg: FKRegistry):
-	registry = reg
-	
-var registry: FKRegistry
 
 func populate_from_scene(scene_root: Node) -> void:
 	if not item_list:
@@ -289,9 +269,3 @@ func _on_recent_item_activated(index: int) -> void:
 	print("Recent node selected: ", node_path_str, " (", node_class, ")")
 	node_selected.emit(node_path_str, node_class)
 	hide()
-
-func _exit_tree() -> void:
-	if is_editor_preview:
-		return
-		
-	_toggle_subs(false)

--- a/addons/flowkit/ui/modals/select_node_modal.tscn
+++ b/addons/flowkit/ui/modals/select_node_modal.tscn
@@ -2,17 +2,21 @@
 
 [ext_resource type="Script" uid="uid://dbwkcp776nx4d" path="res://addons/flowkit/ui/modals/select_node_modal.gd" id="1_select"]
 
-[node name="select" type="PopupPanel"]
+[node name="select" type="PopupPanel" unique_id=356234721 node_paths=PackedStringArray("search_box", "item_list", "recent_item_list")]
 oversampling_override = 1.0
 title = "Select a Node"
-initial_position = 0
+position = Vector2i(0, 36)
 size = Vector2i(900, 600)
+visible = true
+unresizable = false
 borderless = false
 keep_title_visible = true
 script = ExtResource("1_select")
-unresizable = false
+search_box = NodePath("VBoxContainer/SearchBox")
+item_list = NodePath("VBoxContainer/HSplitContainer/MainPanel/MainVBox/ItemList")
+recent_item_list = NodePath("VBoxContainer/HSplitContainer/RecentPanel/RecentVBox/RecentItemList")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
+[node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=1619432561]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -23,21 +27,22 @@ offset_bottom = -4.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="SearchBox" type="LineEdit" parent="VBoxContainer"]
+[node name="SearchBox" type="LineEdit" parent="VBoxContainer" unique_id=922815758]
 layout_mode = 2
 placeholder_text = "Search..."
 
-[node name="HSplitContainer" type="HSplitContainer" parent="VBoxContainer"]
+[node name="HSplitContainer" type="HSplitContainer" parent="VBoxContainer" unique_id=1721677272]
 layout_mode = 2
 size_flags_vertical = 3
+split_offsets = PackedInt32Array(450)
 split_offset = 450
 
-[node name="RecentPanel" type="Panel" parent="VBoxContainer/HSplitContainer"]
-layout_mode = 2
+[node name="RecentPanel" type="Panel" parent="VBoxContainer/HSplitContainer" unique_id=1357169622]
 custom_minimum_size = Vector2(400, 0)
+layout_mode = 2
 
-[node name="RecentVBox" type="VBoxContainer" parent="VBoxContainer/HSplitContainer/RecentPanel"]
-anchors_preset = 15
+[node name="RecentVBox" type="VBoxContainer" parent="VBoxContainer/HSplitContainer/RecentPanel" unique_id=1087125423]
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = 4.0
@@ -47,21 +52,22 @@ offset_bottom = -4.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="RecentLabel" type="Label" parent="VBoxContainer/HSplitContainer/RecentPanel/RecentVBox"]
+[node name="RecentLabel" type="Label" parent="VBoxContainer/HSplitContainer/RecentPanel/RecentVBox" unique_id=519244250]
 layout_mode = 2
 text = "Recent"
-theme_type_variations = ["header_small"]
 
-[node name="RecentItemList" type="ItemList" parent="VBoxContainer/HSplitContainer/RecentPanel/RecentVBox"]
+[node name="RecentItemList" type="ItemList" parent="VBoxContainer/HSplitContainer/RecentPanel/RecentVBox" unique_id=1374214700]
 layout_mode = 2
 size_flags_vertical = 3
+item_count = 1
+item_0/text = "System"
 
-[node name="MainPanel" type="Panel" parent="VBoxContainer/HSplitContainer"]
+[node name="MainPanel" type="Panel" parent="VBoxContainer/HSplitContainer" unique_id=1885117515]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="MainVBox" type="VBoxContainer" parent="VBoxContainer/HSplitContainer/MainPanel"]
-anchors_preset = 15
+[node name="MainVBox" type="VBoxContainer" parent="VBoxContainer/HSplitContainer/MainPanel" unique_id=1469260602]
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = 4.0
@@ -71,11 +77,10 @@ offset_bottom = -4.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="AllLabel" type="Label" parent="VBoxContainer/HSplitContainer/MainPanel/MainVBox"]
+[node name="AllLabel" type="Label" parent="VBoxContainer/HSplitContainer/MainPanel/MainVBox" unique_id=510950131]
 layout_mode = 2
 text = "All Nodes"
-theme_type_variations = ["header_small"]
 
-[node name="ItemList" type="ItemList" parent="VBoxContainer/HSplitContainer/MainPanel/MainVBox"]
+[node name="ItemList" type="ItemList" parent="VBoxContainer/HSplitContainer/MainPanel/MainVBox" unique_id=1260492874]
 layout_mode = 2
 size_flags_vertical = 3


### PR DESCRIPTION
# Summary
Did a round of cleanup and quality‑of‑life improvements to the modal window system. Nothing behavior‑changing. Just making the whole setup cleaner, safer, and easier to work with.

# What's New
- Modal windows are no longer pre‑instantiated in main_editor.tscn
  - FKMainEditor now spawns them when needed, so it always picks up the latest modal designs without anyone having to remember to update the scene
- Runtime‑only logic no longer fires in editor preview
  - This applies to both the modals and FKMainEditor, so no more preview‑time errors
- Swapped onready UI fields for export fields
  - Makes the UI way easier to tweak visually
- All modals now inherit from a shared base class (FKModalWindow)
  - Centralizes the shared behavior and cuts down on repeated code

# Benefits of These Changes
- Designers can customize modal visuals without spelunking through scripts
- The process of creating new modal window classes is now more programmer-friendly
- Updating modal scenes won’t accidentally leave the editor using stale versions
- main_editor.tscn is noticeably smaller and cleaner
- Less duplicated logic across modal implementations

# Misc Polish
- Removed a lot of print statements we don’t need anymore
- Cleaned up several remaining prints so debugging is easier to follow
- FlowKit’s main class now instantiates submodules via ClassName.new() instead of loading the script file first
- Removed dead code like FKMainEditor._setup_ui()
- Fixed PrintMessage so it defaults _color_input to "white" properly
- Cleaned up redundant Action entries in the demo scenes
- Standardized private member naming (_field_name) in a few scripts so it’s clearer what’s internal vs. public