### PR TITLE
Id Assignment for FKUnits + Architectural Improvements

### DIFF
--- a/addons/flowkit/editor/Ui/main_editor.gd
+++ b/addons/flowkit/editor/Ui/main_editor.gd
@@ -83,11 +83,15 @@ func _enter_tree() -> void:
 
 func _ready() -> void:
 	if is_fully_legit:
-		await get_tree().create_timer(1.0).timeout
-		sheet_state_tracker.enabled = true
-		# ^We apply this delay to make sure that no snapshots are recorded before the 
-		# full ui is initially built
+		await _disable_sheet_tracker_for(1)
+		
 
+func _disable_sheet_tracker_for(duration: float):
+	sheet_state_tracker.enabled = false 
+	await get_tree().create_timer(duration).timeout
+	sheet_state_tracker.enabled = true
+	# ^We apply this delay to make sure that no snapshots are recorded before the 
+		# full ui is initially built
 
 func _apply_auto_save_enablement():
 	var auto_save_setting_registered: bool = \
@@ -659,6 +663,7 @@ var current_scene_uid: int:
 
 func _reset_for_new_scene(scene_uid: int):
 	current_scene_uid = scene_uid
+	_disable_sheet_tracker_for(1)
 	_clear_undo_history()
 	editor_globals.sheet_editor_ready = false
 	_refresh_ui()

--- a/addons/flowkit/editor/sheet_io.gd
+++ b/addons/flowkit/editor/sheet_io.gd
@@ -19,11 +19,13 @@ func load_sheet(scene_uid: int) -> FKEventSheet:
 
 	var sheet := ResourceLoader.load(sheet_path)
 	if sheet is FKEventSheet:
+		sheet.on_loaded_from_disk()
 		return sheet
 	return null
 
 func save_sheet(scene_uid: int, sheet: FKEventSheet) -> int:
 	var sheet_path := get_sheet_path(scene_uid)
+	sheet.refresh() # To ensure any cleanup is done
 	if sheet_path == "":
 		print("[SheetIo] Returning err invalid param")
 		return ERR_INVALID_PARAMETER

--- a/addons/flowkit/resources/event_sheet.gd
+++ b/addons/flowkit/resources/event_sheet.gd
@@ -14,8 +14,7 @@ class_name FKEventSheet
 
 ## Stores the display order: [{"type": "event"|"comment"|"group", "index": int}, ...]
 @export var item_order: Array[Dictionary] = []
-
-@export_storage var _latest_uid_given := FKUnit.INVALID_ID
+var _id_assigner: FKIdAssigner = FKIdAssigner.new()
 
 ## Returns an array of the top-level FKUnits in the order they were
 ## appended to this sheet.
@@ -171,51 +170,23 @@ func on_loaded_from_disk():
 	refresh()
 
 func refresh():
+	_id_assigner.prop_name = "personal_id"
+	_id_assigner._append_array_as_invalid([0, FKUnit.INVALID_ID])
 	_refresh_uids()
 
 # For backwards compatibility with older versions of FlowKit
 func _refresh_uids():
-	var taken_ids: Array[int] = [FKUnit.INVALID_ID]
-	# ^Why does it start with the invalid id? To simplify the process of 
-	# ensuring our FKUnits have unique ones.
-
-	_ensure_uids_in(events, taken_ids)
-	_ensure_uids_in(standalone_conditions, taken_ids)
-	_ensure_uids_in(comments, taken_ids)
-	_ensure_uids_in(groups, taken_ids)
-
-	_latest_uid_given = taken_ids.max()
-
-func _ensure_uids_in(units: Array, taken_ids: Array[int]):
-	for elem in units:
-		var unit_elem: FKUnit = elem as FKUnit if elem is FKUnit else null
-
-		if unit_elem == null:
-			printerr("[FKEventSheets] Skipping non-FKUnit element during UID refresh.")
-			continue
-
-		while taken_ids.has(unit_elem.personal_id):
-			_assign_next_uid_to(unit_elem)
-		
-		taken_ids.append(unit_elem.personal_id)
-
-		if unit_elem is FKGroup:
-			_ensure_uids_in(unit_elem.children, taken_ids)
-		
-		var action_unit: FKActionUnit = elem as FKActionUnit if elem is FKActionUnit else null
-		if action_unit != null:
-			_ensure_uids_in(unit_elem.branch_actions, taken_ids)
-
-
-func _assign_next_uid_to(unit: FKUnit):
-	unit.personal_id = _latest_uid_given + 1
-	_latest_uid_given = unit.personal_id
+	_id_assigner.reset_taken_caches()
+	_id_assigner.refresh_for(events)
+	_id_assigner.refresh_for(standalone_conditions)
+	_id_assigner.refresh_for(comments)
+	_id_assigner.refresh_for(groups)
 
 func get_class() -> String:
 	return "FKEventSheet"
 
 func _to_string() -> String:
-	var result := "FKEventSheet"
+	var result := "FKEventSheet\n"
 	result += "Events: " + str(events) + "\n"
 	result += "Standalone Conditions: " + str(standalone_conditions) + "\n"
 	result += "Comments: " + str(comments) + "\n"

--- a/addons/flowkit/resources/event_sheet.gd
+++ b/addons/flowkit/resources/event_sheet.gd
@@ -15,6 +15,8 @@ class_name FKEventSheet
 ## Stores the display order: [{"type": "event"|"comment"|"group", "index": int}, ...]
 @export var item_order: Array[Dictionary] = []
 
+@export_storage var _latest_uid_given := FKUnit.INVALID_ID
+
 ## Returns an array of the top-level FKUnits in the order they were
 ## appended to this sheet.
 var ordered_items: Array[FKUnit]:
@@ -164,6 +166,58 @@ func rebuild_order_from_items(ordered_items: Array) -> void:
 				if data is FKGroup:
 					item_order.append({"type": "group", "index": groups.size()})
 					groups.append(data)
-					
+
+func on_loaded_from_disk():
+	refresh()
+
+func refresh():
+	_refresh_uids()
+
+# For backwards compatibility with older versions of FlowKit
+func _refresh_uids():
+	var taken_ids: Array[int] = [FKUnit.INVALID_ID]
+	# ^Why does it start with the invalid id? To simplify the process of 
+	# ensuring our FKUnits have unique ones.
+
+	_ensure_uids_in(events, taken_ids)
+	_ensure_uids_in(standalone_conditions, taken_ids)
+	_ensure_uids_in(comments, taken_ids)
+	_ensure_uids_in(groups, taken_ids)
+
+	_latest_uid_given = taken_ids.max()
+
+func _ensure_uids_in(units: Array, taken_ids: Array[int]):
+	for elem in units:
+		var unit_elem: FKUnit = elem as FKUnit if elem is FKUnit else null
+
+		if unit_elem == null:
+			printerr("[FKEventSheets] Skipping non-FKUnit element during UID refresh.")
+			continue
+
+		while taken_ids.has(unit_elem.personal_id):
+			_assign_next_uid_to(unit_elem)
+		
+		taken_ids.append(unit_elem.personal_id)
+
+		if unit_elem is FKGroup:
+			_ensure_uids_in(unit_elem.children, taken_ids)
+		
+		var action_unit: FKActionUnit = elem as FKActionUnit if elem is FKActionUnit else null
+		if action_unit != null:
+			_ensure_uids_in(unit_elem.branch_actions, taken_ids)
+
+
+func _assign_next_uid_to(unit: FKUnit):
+	unit.personal_id = _latest_uid_given + 1
+	_latest_uid_given = unit.personal_id
+
 func get_class() -> String:
 	return "FKEventSheet"
+
+func _to_string() -> String:
+	var result := "FKEventSheet"
+	result += "Events: " + str(events) + "\n"
+	result += "Standalone Conditions: " + str(standalone_conditions) + "\n"
+	result += "Comments: " + str(comments) + "\n"
+	result += "Groups : " + str(groups) + "\n"
+	return result

--- a/addons/flowkit/resources/event_sheet.gd
+++ b/addons/flowkit/resources/event_sheet.gd
@@ -14,7 +14,7 @@ class_name FKEventSheet
 
 ## Stores the display order: [{"type": "event"|"comment"|"group", "index": int}, ...]
 @export var item_order: Array[Dictionary] = []
-var _id_assigner: FKIdAssigner = FKIdAssigner.new()
+@export_storage var _id_assigner: FKIdAssigner
 
 ## Returns an array of the top-level FKUnits in the order they were
 ## appended to this sheet.
@@ -167,20 +167,52 @@ func rebuild_order_from_items(ordered_items: Array) -> void:
 					groups.append(data)
 
 func on_loaded_from_disk():
+	_call_child_on_loaded_from_disk(events)
+	_call_child_on_loaded_from_disk(standalone_conditions)
+	_call_child_on_loaded_from_disk(comments)
+	_call_child_on_loaded_from_disk(groups)
 	refresh()
 
+func _call_child_on_loaded_from_disk(children: Array):
+	for elem in children:
+		var fk_unit := elem as FKUnit
+		#print("Calling on_loaded_from_disk for instance of " + fk_unit.get_real_class())
+		fk_unit.on_loaded_from_disk()
+
 func refresh():
+	if not _id_assigner:
+		_id_assigner = FKIdAssigner.new()
+		
 	_id_assigner.prop_name = "personal_id"
 	_id_assigner._append_array_as_invalid([0, FKUnit.INVALID_ID])
 	_refresh_uids()
 
 # For backwards compatibility with older versions of FlowKit
 func _refresh_uids():
-	_id_assigner.reset_taken_caches()
-	_id_assigner.refresh_for(events)
-	_id_assigner.refresh_for(standalone_conditions)
-	_id_assigner.refresh_for(comments)
-	_id_assigner.refresh_for(groups)
+	print("[FKEventSheet]: Refreshing uids")
+	_refresh_uids_in_array(events)
+	_refresh_uids_in_array(standalone_conditions)
+	_refresh_uids_in_array(comments)
+	_refresh_uids_in_array(groups)
+
+
+func _refresh_uids_in_array(arr: Array):
+	for elem in arr:
+		var unit := elem as FKUnit
+		if unit == null:
+			continue
+
+		_assign_uid_recursive(unit)
+
+
+func _assign_uid_recursive(unit: FKUnit):
+	var assigned := _id_assigner.refresh_for([unit])
+	# print("Assigning uid " + str(assigned) + " to " + unit.get_real_class())
+	var childArr := unit.get_children()
+
+	for child in childArr:
+		_assign_uid_recursive(child)
+
 
 func get_class() -> String:
 	return "FKEventSheet"

--- a/addons/flowkit/runtime/Units/action_unit.gd
+++ b/addons/flowkit/runtime/Units/action_unit.gd
@@ -6,6 +6,8 @@ class_name FKActionUnit
 @export var target_node: NodePath
 @export var inputs: Dictionary = {}
 
+@export var weee: int = 123
+
 # Branch support
 @export var is_branch: bool = false
 @export var branch_type: String = ""              # "if", "elseif", "else", etc.
@@ -18,8 +20,8 @@ func _init() -> void:
 	block_type = "action"
 
 func serialize() -> Dictionary:
-	var result := {
-		"type": block_type,
+	var result := super.serialize()
+	var our_added_fields := {
 		"action_id": action_id,
 		"target_node": str(target_node),
 		"inputs": inputs.duplicate(),
@@ -28,6 +30,7 @@ func serialize() -> Dictionary:
 		"branch_id": branch_id,
 		"branch_inputs": branch_inputs.duplicate()
 	}
+	result.merge(our_added_fields)
 
 	_serialize_branch_conds_and_actions(result)
 
@@ -45,6 +48,8 @@ func _serialize_branch_conds_and_actions(result: Dictionary):
 		result["branch_actions"] = copied_actions
 		
 func deserialize(dict: Dictionary) -> void:
+	print("Deserializing fk action")
+	super.deserialize(dict)
 	action_id = dict.get("action_id", "")
 	target_node = NodePath(dict.get("target_node", ""))
 	inputs = dict.get("inputs", {}).duplicate()
@@ -77,6 +82,7 @@ func duplicate_block() -> FKUnit:
 	#print("[FKActionUnit]: Duplicating!")
 	var copy := FKActionUnit.new()
 	copy.block_type = block_type
+	copy.personal_id = personal_id
 	copy.action_id = action_id
 	copy.target_node = target_node
 	copy.inputs = inputs.duplicate(true)
@@ -93,10 +99,6 @@ func duplicate_block() -> FKUnit:
 		branch_actions_copy.append(act_copy)
 	copy.branch_actions = branch_actions_copy
 		
-	# Copy your other fields here (ids, params, etc.)
-	# e.g. copy.action_id = action_id, etc.
-
-
 	return copy
 	
 static func _to_action_unit_arr(arr: Array) -> Array[FKActionUnit]:

--- a/addons/flowkit/runtime/Units/action_unit.gd
+++ b/addons/flowkit/runtime/Units/action_unit.gd
@@ -6,8 +6,6 @@ class_name FKActionUnit
 @export var target_node: NodePath
 @export var inputs: Dictionary = {}
 
-@export var weee: int = 123
-
 # Branch support
 @export var is_branch: bool = false
 @export var branch_type: String = ""              # "if", "elseif", "else", etc.
@@ -15,6 +13,14 @@ class_name FKActionUnit
 @export var branch_condition: FKConditionUnit = null
 @export var branch_inputs: Dictionary = {}
 @export var branch_actions: Array[FKActionUnit] = []
+
+func may_have_children() -> bool:
+	return true
+
+func get_children() -> Array[FKUnit]:
+	var defensive_copy: Array[FKUnit] = [] as Array[FKUnit]
+	defensive_copy.append_array(branch_actions)
+	return defensive_copy
 
 func _init() -> void:
 	block_type = "action"
@@ -35,6 +41,7 @@ func serialize() -> Dictionary:
 	_serialize_branch_conds_and_actions(result)
 
 	return result
+
 
 func _serialize_branch_conds_and_actions(result: Dictionary):
 	if is_branch and branch_condition != null:

--- a/addons/flowkit/runtime/Units/base_unit.gd
+++ b/addons/flowkit/runtime/Units/base_unit.gd
@@ -2,25 +2,48 @@
 extends Resource
 class_name FKUnit
 
-@export var block_type: String = ""   # "event", "comment", "group"
+const INVALID_ID := 0
 
-# Optional: editor-friendly name for menus, debugging, etc.
+@export var block_type: String = ""   # "event", "comment", "group": 
+
+## This is meant to be relative to the Event Sheet it belongs to, as opposed
+## to being globally exclusive.
+@export var personal_id: int = INVALID_ID:
+	set(value):
+		if personal_id == null: # This is expected after reading older FKUnits from disk
+			personal_id = INVALID_ID
+
+		if value < INVALID_ID:
+			print("[FKUnit] I was passed a negative personal_id. It may be a sign of an "+\
+			"issue elsewhere.")
+			personal_id = INVALID_ID
+			return
+
+		personal_id = value
+	get:
+		return personal_id
+
+# Editor-friendly name for menus, debugging, etc.
 func get_display_name() -> String:
 	return block_type.capitalize()
 
 # Subclasses override this to return a Dictionary representation.
 func serialize() -> Dictionary:
-	push_error("serialize() not implemented for %s" % block_type)
-	return {}
+	print("Serializing an FKUnit")
+	var result: Dictionary = {
+		"type": block_type,
+		"personal_id": personal_id
+	}
+	return result
 
 ## Subclasses override this to populate themselves from a Dictionary.
-##
-##
 func deserialize(dict: Dictionary) -> void:
-	push_error("deserialize() not implemented for %s" % block_type)
+	print("Deserializing fk unit base")
+	personal_id = dict.get("personal_id")
 
 # Deep-copy contract for undo/redo and clipboard.
 func duplicate_block() -> FKUnit:
+	print("Duplicating an fkunit")
 	var copy := self.duplicate(true)
 	return copy
 	
@@ -46,3 +69,8 @@ static func _to_base_unit_arr(arr: Array) -> Array[FKUnit]:
 
 func get_class() -> String:
 	return "FKUnit"
+
+func _to_string() -> String:
+	var self_serialized: Dictionary = self.serialize()
+	var result = "(" + self.get_display_name() + ")" + "\n" + JSON.stringify(self_serialized, "\t")
+	return result

--- a/addons/flowkit/runtime/Units/base_unit.gd
+++ b/addons/flowkit/runtime/Units/base_unit.gd
@@ -23,6 +23,33 @@ const INVALID_ID := 0
 	get:
 		return personal_id
 
+func may_have_children():
+	return false 
+
+## Called after this FKUnit has been fully deserialized from disk 
+## into an FKEventSheet instance.
+## Makes it easier for this to do things like:
+## - Normalize or upgrade legacy serialized data
+## - Self-repair
+## - Re‑establish metadata
+func on_loaded_from_disk():
+	_call_children_on_loaded_from_disk()
+	
+func _call_children_on_loaded_from_disk():
+	var message: String = ""
+	var children := get_children()
+	for elem in children:
+		# message = "Instance of %s is calling its %s child's on_loaded_from_disk" \
+		# % [self.get_class(), elem.get_real_class()]
+		# print(message)
+		
+		elem.on_loaded_from_disk()
+
+## Accessor for this FKUnit's child units. Child classes (if they are intended to have child units)
+## are expected to override this.
+func get_children() -> Array[FKUnit]:
+	return []
+
 # Editor-friendly name for menus, debugging, etc.
 func get_display_name() -> String:
 	return block_type.capitalize()
@@ -69,6 +96,11 @@ static func _to_base_unit_arr(arr: Array) -> Array[FKUnit]:
 
 func get_class() -> String:
 	return "FKUnit"
+
+## We need this so that even when cast to another type, we get the right
+## get_class result.
+func get_real_class() -> String:
+	return self.get_class()
 
 func _to_string() -> String:
 	var self_serialized: Dictionary = self.serialize()

--- a/addons/flowkit/runtime/Units/comment_unit.gd
+++ b/addons/flowkit/runtime/Units/comment_unit.gd
@@ -8,12 +8,12 @@ func _init() -> void:
 	block_type = "comment"
 
 func serialize() -> Dictionary:
-	return {
-		"type": block_type,
-		"text": text,
-	}
+	var result := super.serialize()
+	result["text"] = text
+	return result
 
 func deserialize(dict: Dictionary) -> void:
+	super.deserialize(dict)
 	text = dict.get("text", "")
 	
 func duplicate_block() -> FKUnit:

--- a/addons/flowkit/runtime/Units/condition_unit.gd
+++ b/addons/flowkit/runtime/Units/condition_unit.gd
@@ -12,13 +12,16 @@ func _init() -> void:
 	block_type = "condition"
 
 func serialize() -> Dictionary:
-	return {
-		"type": block_type,
+	var result := super.serialize()
+	var our_added_fields := {
 		"condition_id": condition_id,
 		"target_node": str(target_node),
 		"inputs": inputs.duplicate(),
 		"negated": negated,
 	}
+	result.merge(our_added_fields)
+	
+	return result
 
 func deserialize(dict: Dictionary) -> void:
 	condition_id = dict.get("condition_id", "")

--- a/addons/flowkit/runtime/Units/condition_unit.gd
+++ b/addons/flowkit/runtime/Units/condition_unit.gd
@@ -11,6 +11,14 @@ class_name FKConditionUnit
 func _init() -> void:
 	block_type = "condition"
 
+func may_have_children():
+	return true 
+	
+func get_children() -> Array[FKUnit]:
+	var defensive_copy: Array[FKUnit] = [] as Array[FKUnit]
+	defensive_copy.append_array(actions)
+	return defensive_copy
+	
 func serialize() -> Dictionary:
 	var result := super.serialize()
 	var our_added_fields := {

--- a/addons/flowkit/runtime/Units/event_block.gd
+++ b/addons/flowkit/runtime/Units/event_block.gd
@@ -8,7 +8,16 @@ class_name FKEventUnit
 @export var inputs: Dictionary = {}
 @export var conditions: Array[FKConditionUnit] = []
 @export var actions: Array[FKActionUnit] = []
-	
+
+func may_have_children() -> bool:
+	return true
+
+func get_children() -> Array[FKUnit]:
+	var defensive_copy: Array[FKUnit] = [] as Array[FKUnit]
+	defensive_copy.append_array(conditions)
+	defensive_copy.append_array(actions)
+	return defensive_copy
+
 func _init(p_block_id: String = "", p_event_id: String = "", 
 p_target_node: NodePath = NodePath()) -> void:
 	block_type = "event"
@@ -23,6 +32,7 @@ p_target_node: NodePath = NodePath()) -> void:
 func _generate_unique_id() -> String:
 	"""Generate a unique ID for this block using timestamp and random component."""
 	var timestamp = Time.get_unix_time_from_system()
+	# event_id can be stuff like "on_ready" and "on_process"
 	return "%s_%d_%d" % [event_id if event_id else "event", int(timestamp), randi()]
 
 func ensure_block_id() -> void:
@@ -49,6 +59,7 @@ func serialize() -> Dictionary:
 		result["actions"].append(act.serialize())
 
 	return result
+
 
 func deserialize(dict: Dictionary) -> void:
 	block_id = dict.get("block_id", "")

--- a/addons/flowkit/runtime/Units/event_block.gd
+++ b/addons/flowkit/runtime/Units/event_block.gd
@@ -31,8 +31,8 @@ func ensure_block_id() -> void:
 		block_id = _generate_unique_id()
 		
 func serialize() -> Dictionary:
-	var result := {
-		"type": block_type,
+	var result := super.serialize()
+	var our_added_fields := {
 		"block_id": block_id,
 		"event_id": event_id,
 		"target_node": str(target_node),
@@ -40,6 +40,7 @@ func serialize() -> Dictionary:
 		"conditions": [],
 		"actions": []
 	}
+	result.merge(our_added_fields)
 
 	for cond in conditions:
 		result["conditions"].append(cond.serialize())

--- a/addons/flowkit/runtime/Units/group_unit.gd
+++ b/addons/flowkit/runtime/Units/group_unit.gd
@@ -18,6 +18,15 @@ static var _serialization_manager := FKSerializationManager.new()
 func _init() -> void:
 	block_type = "group"
 
+func may_have_children() -> bool:
+	return true
+
+func get_children() -> Array[FKUnit]:
+	normalize_children()
+	var defensive_copy: Array[FKUnit] = [] as Array[FKUnit]
+	defensive_copy.append_array(children)
+	return defensive_copy
+
 func normalize_children(force: bool = false) -> void:
 	if _is_normalized and not force:
 		return
@@ -41,7 +50,6 @@ func normalize_children(force: bool = false) -> void:
 
 var _is_normalized := false
 
-# Optional helpers if you still want them, but FKUnit-only now
 func add_child_unit(unit: FKUnit) -> void:
 	if unit:
 		children.append(unit)
@@ -54,7 +62,8 @@ func get_child_count() -> int:
 	return children.size()
 
 func get_child_unit(index: int) -> FKUnit:
-	if index >= 0 and index < children.size():
+	var valid_index: bool = index >= 0 and index < children.size()
+	if valid_index:
 		return children[index]
 	return null
 

--- a/addons/flowkit/runtime/Units/group_unit.gd
+++ b/addons/flowkit/runtime/Units/group_unit.gd
@@ -66,14 +66,16 @@ func find_child_index(unit: FKUnit) -> int:
 
 func serialize() -> Dictionary:
 	normalize_children(true)
-	
-	var result := {
-		"type": block_type,
+
+	var result := super.serialize()
+	var our_added_fields := {
 		"title": title,
 		"collapsed": collapsed,
 		"color": color,
 		"children": _get_serialized_children(self)
 	}
+	result.merge(our_added_fields)
+
 	return result
 
 static func _get_serialized_children(block: FKGroup) -> Array:
@@ -85,6 +87,8 @@ static func _get_serialized_children(block: FKGroup) -> Array:
 	return result
 
 func deserialize(dict: Dictionary) -> void:
+	print("Deserializing fk group")
+	super.deserialize(dict)
 	title = dict.get("title", "Group")
 	collapsed = dict.get("collapsed", false)
 	color = dict.get("color", Color(0.25, 0.22, 0.35, 1.0))

--- a/addons/flowkit/runtime/id_assigner.gd
+++ b/addons/flowkit/runtime/id_assigner.gd
@@ -1,0 +1,108 @@
+extends Resource
+class_name FKIdAssigner
+
+## Highest ID found during the last refresh.
+var _latest_id_given: int = -1
+
+## It is assumed that all elements inherit from Object
+func refresh_for(items: Array):
+	_validate_and_register_init_taken_ids(items)
+	_refresh_latest_id_given()
+	_assign_new_ids_as_needed(items)
+	_refresh_latest_id_given() # To take the new assignments into account
+
+	return _latest_id_given
+
+func _validate_and_register_init_taken_ids(items: Array):
+	var error_message := ""
+	for elem in items:
+		if not elem.has_method("get"):
+			error_message = _GET_METHOD_MISSING % elem
+			push_error(error_message)
+			continue
+
+		var current_id = elem.get(prop_name)
+
+		var wrong_type: bool = current_id != null and typeof(current_id) != TYPE_INT
+		if wrong_type:
+			error_message = _INVALID_PROP_TYPE % [prop_name, elem]
+			push_error(error_message)
+			continue
+
+		var found_valid_id: bool = current_id != null
+		if found_valid_id:
+			_taken_ids.append(current_id)
+
+
+const _GET_METHOD_MISSING := "[FKIdAssigner]: element does not support get(): %s. " +\
+			"Items must each inherit from Object."
+
+const _INVALID_PROP_TYPE := "[FKIdAssigner]: property %s must be an int or null on %s"
+
+## Name of the property that stores the unit's ID, which should be an int.
+## Clients are expected to set this.
+var prop_name: String = "":
+	get:
+		return prop_name
+	set(value):
+		prop_name = value	
+
+func _refresh_latest_id_given():
+	_latest_id_given = _taken_ids.min()
+	for id in _taken_ids:
+		if id > _latest_id_given:
+			_latest_id_given = id
+
+func reset_taken_caches():
+	_taken_ids.clear()
+	_taken_ids.append_array(_invalid_ids) 
+	# ^So we don't need to check specifically for invalid ids
+
+	_latest_id_given = _taken_ids.min()
+	# ^Helps us avoid assigning needlessly-high ids upon duplication and such
+
+var _taken_ids: Array[int] = []
+
+func _append_array_as_invalid(new_invalids: Array[int]):
+	for elem in new_invalids:
+		_append_as_invalid(elem)
+
+func _append_as_invalid(new_invalid: int):
+	if not _invalid_ids.has(new_invalid):
+		_invalid_ids.append(new_invalid)
+
+func _remove_array_as_invalid(invalids: Array[int]):
+	for elem in invalids:
+		_remove_as_invalid(elem)
+
+func _remove_as_invalid(invalid: int):
+	var ind := _invalid_ids.find(invalid)
+	if ind >= 0:
+		_invalid_ids.remove_at(ind) 
+
+var _invalid_ids: Array[int] = [0, -1]
+# ^Any magic numbers here are common values for invalid ids.
+
+func _assign_new_ids_as_needed(items: Array):
+	# At this point, we assume that all the contents inherit from Object
+	for elem in items:
+		var current_id = elem.get(prop_name)
+
+		var wrong_type: bool = typeof(current_id) != TYPE_INT
+		var is_dupe: bool = _taken_ids.count(current_id) > 1
+		var needs_new_id: bool = (
+			current_id == null
+			or wrong_type
+			or is_dupe
+		)
+
+		if needs_new_id:
+			current_id = _assign_next_uid_to(elem)
+
+		_taken_ids.append(current_id)
+
+func _assign_next_uid_to(unit: Object) -> int:
+	var new_id: int = _latest_id_given + 1
+	unit.set(prop_name, new_id)
+	_latest_id_given = new_id
+	return new_id

--- a/addons/flowkit/runtime/id_assigner.gd
+++ b/addons/flowkit/runtime/id_assigner.gd
@@ -1,11 +1,12 @@
+@tool
 extends Resource
 class_name FKIdAssigner
 
 ## Highest ID found during the last refresh.
-var _latest_id_given: int = -1
+@export_storage var _latest_id_given: int = -1
 
 ## It is assumed that all elements inherit from Object
-func refresh_for(items: Array):
+func refresh_for(items: Array) -> int:
 	_validate_and_register_init_taken_ids(items)
 	_refresh_latest_id_given()
 	_assign_new_ids_as_needed(items)
@@ -106,3 +107,6 @@ func _assign_next_uid_to(unit: Object) -> int:
 	unit.set(prop_name, new_id)
 	_latest_id_given = new_id
 	return new_id
+
+func get_real_class() -> String:
+	return "FKIdAssigner"

--- a/addons/flowkit/runtime/id_assigner.gd.uid
+++ b/addons/flowkit/runtime/id_assigner.gd.uid
@@ -1,0 +1,1 @@
+uid://bfctyysd72b6p

--- a/addons/flowkit/saved/event_sheet/1035986417700190942.tres
+++ b/addons/flowkit/saved/event_sheet/1035986417700190942.tres
@@ -1,5 +1,6 @@
 [gd_resource type="Resource" script_class="FKEventSheet" format=3 uid="uid://dyirwydnynnl8"]
 
+[ext_resource type="Script" uid="uid://bfctyysd72b6p" path="res://addons/flowkit/runtime/id_assigner.gd" id="1_ehuoq"]
 [ext_resource type="Script" uid="uid://b1y3c8rnt2rcg" path="res://addons/flowkit/runtime/Units/comment_unit.gd" id="1_opms0"]
 [ext_resource type="Script" uid="uid://bxdhylwvr4osy" path="res://addons/flowkit/runtime/Units/event_block.gd" id="2_at6cs"]
 [ext_resource type="Script" path="res://addons/flowkit/runtime/Units/group_unit.gd" id="3_ehuoq"]
@@ -7,12 +8,17 @@
 [ext_resource type="Script" uid="uid://bumsyiqkp46l1" path="res://addons/flowkit/resources/event_sheet.gd" id="4_ehuxe"]
 [ext_resource type="Script" uid="uid://bmaxurgrsv4ct" path="res://addons/flowkit/runtime/Units/condition_unit.gd" id="5_1wrk8"]
 
-[sub_resource type="Resource" id="Resource_at6cs"]
+[sub_resource type="Resource" id="Resource_ehuxe"]
+script = ExtResource("1_ehuoq")
+_latest_id_given = 7
+
+[sub_resource type="Resource" id="Resource_1wrk8"]
 script = ExtResource("1_opms0")
 text = "If player falls below the ground, they will teleport back to spawn."
 block_type = "comment"
+personal_id = 1
 
-[sub_resource type="Resource" id="Resource_ehuoq"]
+[sub_resource type="Resource" id="Resource_iu3q8"]
 script = ExtResource("4_at6cs")
 action_id = "set_velocity_y"
 target_node = NodePath("CharacterBody2D")
@@ -20,8 +26,9 @@ inputs = {
 "Y": "0"
 }
 block_type = "action"
+personal_id = 5
 
-[sub_resource type="Resource" id="Resource_ehuxe"]
+[sub_resource type="Resource" id="Resource_n0pkj"]
 script = ExtResource("4_at6cs")
 action_id = "set_position_x"
 target_node = NodePath("CharacterBody2D")
@@ -29,8 +36,9 @@ inputs = {
 "X": "n_initial_x"
 }
 block_type = "action"
+personal_id = 6
 
-[sub_resource type="Resource" id="Resource_1wrk8"]
+[sub_resource type="Resource" id="Resource_hkb6h"]
 script = ExtResource("4_at6cs")
 action_id = "set_position_y"
 target_node = NodePath("CharacterBody2D")
@@ -38,8 +46,9 @@ inputs = {
 "Y": "n_initial_y"
 }
 block_type = "action"
+personal_id = 7
 
-[sub_resource type="Resource" id="Resource_iu3q8"]
+[sub_resource type="Resource" id="Resource_rqmq1"]
 script = ExtResource("5_1wrk8")
 condition_id = "compare_node_variable"
 target_node = NodePath("CharacterBody2D")
@@ -49,26 +58,29 @@ inputs = {
 "Value": "n_lowest_y"
 }
 block_type = "condition"
+personal_id = 3
 
-[sub_resource type="Resource" id="Resource_n0pkj"]
+[sub_resource type="Resource" id="Resource_ch42c"]
 script = ExtResource("2_at6cs")
-block_id = "event_1775511542_917069496"
+block_id = "event_1784483669_713240941"
 event_id = "on_process"
 target_node = NodePath("CharacterBody2D")
-conditions = Array[ExtResource("5_1wrk8")]([SubResource("Resource_iu3q8")])
-actions = Array[ExtResource("4_at6cs")]([SubResource("Resource_ehuoq"), SubResource("Resource_ehuxe"), SubResource("Resource_1wrk8")])
+conditions = Array[ExtResource("5_1wrk8")]([SubResource("Resource_rqmq1")])
+actions = Array[ExtResource("4_at6cs")]([SubResource("Resource_iu3q8"), SubResource("Resource_n0pkj"), SubResource("Resource_hkb6h")])
 block_type = "event"
+personal_id = 2
 
-[sub_resource type="Resource" id="Resource_hkb6h"]
+[sub_resource type="Resource" id="Resource_paa45"]
 script = ExtResource("3_ehuoq")
 title = "Prevent falling off map"
-children = [SubResource("Resource_at6cs"), SubResource("Resource_n0pkj")]
+children = [SubResource("Resource_1wrk8"), SubResource("Resource_ch42c")]
 block_type = "group"
 
 [resource]
 script = ExtResource("4_ehuxe")
-groups = Array[ExtResource("3_ehuoq")]([SubResource("Resource_hkb6h")])
+groups = Array[ExtResource("3_ehuoq")]([SubResource("Resource_paa45")])
 item_order = Array[Dictionary]([{
 "index": 0,
 "type": "group"
 }])
+_id_assigner = SubResource("Resource_ehuxe")

--- a/addons/flowkit/saved/event_sheet/2450759864276140733.tres
+++ b/addons/flowkit/saved/event_sheet/2450759864276140733.tres
@@ -1,5 +1,6 @@
 [gd_resource type="Resource" script_class="FKEventSheet" format=3 uid="uid://d06kj580471mq"]
 
+[ext_resource type="Script" uid="uid://bfctyysd72b6p" path="res://addons/flowkit/runtime/id_assigner.gd" id="1_o0xcg"]
 [ext_resource type="Script" uid="uid://b1y3c8rnt2rcg" path="res://addons/flowkit/runtime/Units/comment_unit.gd" id="1_xv5k1"]
 [ext_resource type="Script" uid="uid://bxdhylwvr4osy" path="res://addons/flowkit/runtime/Units/event_block.gd" id="2_o0xcg"]
 [ext_resource type="Script" uid="uid://bwbi0utcwmxwf" path="res://addons/flowkit/runtime/Units/action_unit.gd" id="3_7puo2"]
@@ -7,7 +8,11 @@
 [ext_resource type="Script" path="res://addons/flowkit/runtime/Units/group_unit.gd" id="5_3014d"]
 [ext_resource type="Script" uid="uid://bumsyiqkp46l1" path="res://addons/flowkit/resources/event_sheet.gd" id="6_0vfw8"]
 
-[sub_resource type="Resource" id="Resource_xv5k1"]
+[sub_resource type="Resource" id="Resource_7puo2"]
+script = ExtResource("1_o0xcg")
+_latest_id_given = 8
+
+[sub_resource type="Resource" id="Resource_ko5ym"]
 script = ExtResource("3_7puo2")
 action_id = "set_window_mode"
 target_node = NodePath("System")
@@ -15,8 +20,9 @@ inputs = {
 "Mode": "\"windowed\""
 }
 block_type = "action"
+personal_id = 1
 
-[sub_resource type="Resource" id="Resource_o0xcg"]
+[sub_resource type="Resource" id="Resource_3014d"]
 script = ExtResource("3_7puo2")
 action_id = "set_window_size"
 target_node = NodePath("System")
@@ -25,8 +31,9 @@ inputs = {
 "Width": "1280"
 }
 block_type = "action"
+personal_id = 2
 
-[sub_resource type="Resource" id="Resource_7puo2"]
+[sub_resource type="Resource" id="Resource_0vfw8"]
 script = ExtResource("3_7puo2")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -35,8 +42,9 @@ inputs = {
 "Value": "1"
 }
 block_type = "action"
+personal_id = 3
 
-[sub_resource type="Resource" id="Resource_ko5ym"]
+[sub_resource type="Resource" id="Resource_v5tg8"]
 script = ExtResource("3_7puo2")
 action_id = "Print Message"
 target_node = NodePath(".")
@@ -47,8 +55,9 @@ inputs = {
 "message": "\"Counting from 1 to 10\""
 }
 block_type = "action"
+personal_id = 4
 
-[sub_resource type="Resource" id="Resource_3014d"]
+[sub_resource type="Resource" id="Resource_l83bg"]
 script = ExtResource("3_7puo2")
 action_id = "Print Message"
 target_node = NodePath(".")
@@ -57,8 +66,9 @@ inputs = {
 "message": "system.get_var(\"times\")"
 }
 block_type = "action"
+personal_id = 6
 
-[sub_resource type="Resource" id="Resource_0vfw8"]
+[sub_resource type="Resource" id="Resource_5nvf0"]
 script = ExtResource("3_7puo2")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -67,8 +77,9 @@ inputs = {
 "Value": "system.get_var(\"times\")+1"
 }
 block_type = "action"
+personal_id = 7
 
-[sub_resource type="Resource" id="Resource_v5tg8"]
+[sub_resource type="Resource" id="Resource_u4oon"]
 script = ExtResource("3_7puo2")
 is_branch = true
 branch_type = "if"
@@ -76,10 +87,11 @@ branch_id = "repeat"
 branch_inputs = {
 "times": "10"
 }
-branch_actions = Array[ExtResource("3_7puo2")]([SubResource("Resource_3014d"), SubResource("Resource_0vfw8")])
+branch_actions = Array[ExtResource("3_7puo2")]([SubResource("Resource_l83bg"), SubResource("Resource_5nvf0")])
 block_type = "action"
+personal_id = 5
 
-[sub_resource type="Resource" id="Resource_l83bg"]
+[sub_resource type="Resource" id="Resource_lus8n"]
 script = ExtResource("3_7puo2")
 action_id = "Print Message"
 target_node = NodePath(".")
@@ -88,19 +100,21 @@ inputs = {
 "message": "\"Done!\""
 }
 block_type = "action"
+personal_id = 8
 
-[sub_resource type="Resource" id="Resource_5nvf0"]
+[sub_resource type="Resource" id="Resource_6ufis"]
 script = ExtResource("2_o0xcg")
-block_id = "event_1778576972_1574968030"
+block_id = "event_1784483667_3370641260"
 event_id = "on_ready"
 target_node = NodePath(".")
-actions = Array[ExtResource("3_7puo2")]([SubResource("Resource_xv5k1"), SubResource("Resource_o0xcg"), SubResource("Resource_7puo2"), SubResource("Resource_ko5ym"), SubResource("Resource_v5tg8"), SubResource("Resource_l83bg")])
+actions = Array[ExtResource("3_7puo2")]([SubResource("Resource_ko5ym"), SubResource("Resource_3014d"), SubResource("Resource_0vfw8"), SubResource("Resource_v5tg8"), SubResource("Resource_u4oon"), SubResource("Resource_lus8n")])
 block_type = "event"
 
 [resource]
 script = ExtResource("6_0vfw8")
-events = Array[ExtResource("2_o0xcg")]([SubResource("Resource_5nvf0")])
+events = Array[ExtResource("2_o0xcg")]([SubResource("Resource_6ufis")])
 item_order = Array[Dictionary]([{
 "index": 0,
 "type": "event"
 }])
+_id_assigner = SubResource("Resource_7puo2")

--- a/addons/flowkit/saved/event_sheet/3722860173612438292.tres
+++ b/addons/flowkit/saved/event_sheet/3722860173612438292.tres
@@ -1,5 +1,6 @@
 [gd_resource type="Resource" script_class="FKEventSheet" format=3 uid="uid://d38xk0ttdal4k"]
 
+[ext_resource type="Script" uid="uid://bfctyysd72b6p" path="res://addons/flowkit/runtime/id_assigner.gd" id="1_cth2l"]
 [ext_resource type="Script" uid="uid://b1y3c8rnt2rcg" path="res://addons/flowkit/runtime/Units/comment_unit.gd" id="1_ljsp5"]
 [ext_resource type="Script" uid="uid://bxdhylwvr4osy" path="res://addons/flowkit/runtime/Units/event_block.gd" id="2_cth2l"]
 [ext_resource type="Script" uid="uid://bwbi0utcwmxwf" path="res://addons/flowkit/runtime/Units/action_unit.gd" id="3_uraip"]
@@ -7,7 +8,11 @@
 [ext_resource type="Script" path="res://addons/flowkit/runtime/Units/group_unit.gd" id="5_jarre"]
 [ext_resource type="Script" uid="uid://bumsyiqkp46l1" path="res://addons/flowkit/resources/event_sheet.gd" id="6_rcit6"]
 
-[sub_resource type="Resource" id="Resource_ljsp5"]
+[sub_resource type="Resource" id="Resource_uraip"]
+script = ExtResource("1_cth2l")
+_latest_id_given = 12
+
+[sub_resource type="Resource" id="Resource_y1g1l"]
 script = ExtResource("3_uraip")
 action_id = "set_window_size"
 target_node = NodePath("System")
@@ -16,8 +21,9 @@ inputs = {
 "Width": "1280"
 }
 block_type = "action"
+personal_id = 1
 
-[sub_resource type="Resource" id="Resource_cth2l"]
+[sub_resource type="Resource" id="Resource_jarre"]
 script = ExtResource("3_uraip")
 action_id = "set_window_mode"
 target_node = NodePath("System")
@@ -25,8 +31,9 @@ inputs = {
 "Mode": "\"windowed\""
 }
 block_type = "action"
+personal_id = 2
 
-[sub_resource type="Resource" id="Resource_uraip"]
+[sub_resource type="Resource" id="Resource_rcit6"]
 script = ExtResource("3_uraip")
 action_id = "set_wait_time"
 target_node = NodePath("Logic/SecondTimer")
@@ -34,8 +41,9 @@ inputs = {
 "Wait Time": "2.0"
 }
 block_type = "action"
+personal_id = 3
 
-[sub_resource type="Resource" id="Resource_y1g1l"]
+[sub_resource type="Resource" id="Resource_h11u5"]
 script = ExtResource("3_uraip")
 action_id = "set_wait_time"
 target_node = NodePath("Logic/ThirdTimer")
@@ -43,37 +51,14 @@ inputs = {
 "Wait Time": "3.0"
 }
 block_type = "action"
-
-[sub_resource type="Resource" id="Resource_jarre"]
-script = ExtResource("2_cth2l")
-block_id = "event_1770577484_3675788766"
-event_id = "on_ready"
-target_node = NodePath("Logic")
-actions = Array[ExtResource("3_uraip")]([SubResource("Resource_ljsp5"), SubResource("Resource_cth2l"), SubResource("Resource_uraip"), SubResource("Resource_y1g1l")])
-block_type = "event"
-
-[sub_resource type="Resource" id="Resource_rcit6"]
-script = ExtResource("3_uraip")
-action_id = "Print Message"
-target_node = NodePath("Logic")
-inputs = {
-"color": "",
-"message": "\"First timer hit timeout. Starting the second one.\""
-}
-block_type = "action"
-
-[sub_resource type="Resource" id="Resource_h11u5"]
-script = ExtResource("3_uraip")
-action_id = "start"
-target_node = NodePath("Logic/SecondTimer")
-block_type = "action"
+personal_id = 4
 
 [sub_resource type="Resource" id="Resource_kn4dn"]
 script = ExtResource("2_cth2l")
-block_id = "event_1770577460_1945654280"
-event_id = "Timer on Timeout"
-target_node = NodePath("Logic/FirstTimer")
-actions = Array[ExtResource("3_uraip")]([SubResource("Resource_rcit6"), SubResource("Resource_h11u5")])
+block_id = "event_1784483659_3639109896"
+event_id = "on_ready"
+target_node = NodePath("Logic")
+actions = Array[ExtResource("3_uraip")]([SubResource("Resource_y1g1l"), SubResource("Resource_jarre"), SubResource("Resource_rcit6"), SubResource("Resource_h11u5")])
 block_type = "event"
 
 [sub_resource type="Resource" id="Resource_h727k"]
@@ -82,25 +67,55 @@ action_id = "Print Message"
 target_node = NodePath("Logic")
 inputs = {
 "color": "",
-"message": "\"Second timer hit timeout. Starting the third one.\""
+"message": "\"First timer hit timeout. Starting the second one.\""
 }
 block_type = "action"
+personal_id = 6
 
 [sub_resource type="Resource" id="Resource_2hg74"]
 script = ExtResource("3_uraip")
 action_id = "start"
-target_node = NodePath("Logic/ThirdTimer")
+target_node = NodePath("Logic/SecondTimer")
 block_type = "action"
+personal_id = 7
 
 [sub_resource type="Resource" id="Resource_3m0o0"]
 script = ExtResource("2_cth2l")
-block_id = "event_1770575621_1822084960"
+block_id = "event_1784483659_1109028942"
 event_id = "Timer on Timeout"
-target_node = NodePath("Logic/SecondTimer")
+target_node = NodePath("Logic/FirstTimer")
 actions = Array[ExtResource("3_uraip")]([SubResource("Resource_h727k"), SubResource("Resource_2hg74")])
 block_type = "event"
+personal_id = 5
 
 [sub_resource type="Resource" id="Resource_dgt5r"]
+script = ExtResource("3_uraip")
+action_id = "Print Message"
+target_node = NodePath("Logic")
+inputs = {
+"color": "",
+"message": "\"Second timer hit timeout. Starting the third one.\""
+}
+block_type = "action"
+personal_id = 9
+
+[sub_resource type="Resource" id="Resource_vag8j"]
+script = ExtResource("3_uraip")
+action_id = "start"
+target_node = NodePath("Logic/ThirdTimer")
+block_type = "action"
+personal_id = 10
+
+[sub_resource type="Resource" id="Resource_kqclp"]
+script = ExtResource("2_cth2l")
+block_id = "event_1784483659_2322954599"
+event_id = "Timer on Timeout"
+target_node = NodePath("Logic/SecondTimer")
+actions = Array[ExtResource("3_uraip")]([SubResource("Resource_dgt5r"), SubResource("Resource_vag8j")])
+block_type = "event"
+personal_id = 8
+
+[sub_resource type="Resource" id="Resource_ljp47"]
 script = ExtResource("3_uraip")
 action_id = "Print Message"
 target_node = NodePath("Logic")
@@ -109,18 +124,20 @@ inputs = {
 "message": "\"Third timer hit timeout. That's all for this demo scene.\""
 }
 block_type = "action"
+personal_id = 12
 
-[sub_resource type="Resource" id="Resource_vag8j"]
+[sub_resource type="Resource" id="Resource_3qpm3"]
 script = ExtResource("2_cth2l")
-block_id = "event_1770575667_4187488692"
+block_id = "event_1784483659_3011195578"
 event_id = "Timer on Timeout"
 target_node = NodePath("Logic/ThirdTimer")
-actions = Array[ExtResource("3_uraip")]([SubResource("Resource_dgt5r")])
+actions = Array[ExtResource("3_uraip")]([SubResource("Resource_ljp47")])
 block_type = "event"
+personal_id = 11
 
 [resource]
 script = ExtResource("6_rcit6")
-events = Array[ExtResource("2_cth2l")]([SubResource("Resource_jarre"), SubResource("Resource_kn4dn"), SubResource("Resource_3m0o0"), SubResource("Resource_vag8j")])
+events = Array[ExtResource("2_cth2l")]([SubResource("Resource_kn4dn"), SubResource("Resource_3m0o0"), SubResource("Resource_kqclp"), SubResource("Resource_3qpm3")])
 item_order = Array[Dictionary]([{
 "index": 0,
 "type": "event"
@@ -134,3 +151,4 @@ item_order = Array[Dictionary]([{
 "index": 3,
 "type": "event"
 }])
+_id_assigner = SubResource("Resource_uraip")

--- a/addons/flowkit/saved/event_sheet/4953409392252150460.tres
+++ b/addons/flowkit/saved/event_sheet/4953409392252150460.tres
@@ -1,5 +1,6 @@
 [gd_resource type="Resource" script_class="FKEventSheet" format=3 uid="uid://b83l5jwe7e8b7"]
 
+[ext_resource type="Script" uid="uid://bfctyysd72b6p" path="res://addons/flowkit/runtime/id_assigner.gd" id="1_1iq3u"]
 [ext_resource type="Script" uid="uid://b1y3c8rnt2rcg" path="res://addons/flowkit/runtime/Units/comment_unit.gd" id="1_6310v"]
 [ext_resource type="Script" uid="uid://bxdhylwvr4osy" path="res://addons/flowkit/runtime/Units/event_block.gd" id="1_iqjwq"]
 [ext_resource type="Script" uid="uid://bwbi0utcwmxwf" path="res://addons/flowkit/runtime/Units/action_unit.gd" id="2_e5301"]
@@ -7,7 +8,11 @@
 [ext_resource type="Script" uid="uid://bumsyiqkp46l1" path="res://addons/flowkit/resources/event_sheet.gd" id="4_1iq3u"]
 [ext_resource type="Script" path="res://addons/flowkit/runtime/Units/group_unit.gd" id="5_1iq3u"]
 
-[sub_resource type="Resource" id="Resource_6310v"]
+[sub_resource type="Resource" id="Resource_1iq3u"]
+script = ExtResource("1_1iq3u")
+_latest_id_given = 35
+
+[sub_resource type="Resource" id="Resource_cbhwn"]
 script = ExtResource("2_e5301")
 action_id = "get_project_setting"
 target_node = NodePath("System")
@@ -16,8 +21,9 @@ inputs = {
 "Store In": "\"gravity\""
 }
 block_type = "action"
+personal_id = 2
 
-[sub_resource type="Resource" id="Resource_1iq3u"]
+[sub_resource type="Resource" id="Resource_jqahe"]
 script = ExtResource("2_e5301")
 action_id = "set_node_variable"
 target_node = NodePath(".")
@@ -26,8 +32,9 @@ inputs = {
 "Variable Name": "\"jump_force\""
 }
 block_type = "action"
+personal_id = 3
 
-[sub_resource type="Resource" id="Resource_cbhwn"]
+[sub_resource type="Resource" id="Resource_qhwv1"]
 script = ExtResource("2_e5301")
 action_id = "set_node_variable"
 target_node = NodePath(".")
@@ -36,16 +43,18 @@ inputs = {
 "Variable Name": "\"speed\""
 }
 block_type = "action"
+personal_id = 4
 
-[sub_resource type="Resource" id="Resource_jqahe"]
+[sub_resource type="Resource" id="Resource_8fi06"]
 script = ExtResource("1_iqjwq")
-block_id = "event_1778968209_1373653493"
+block_id = "event_1784484129_3050620637"
 event_id = "on_ready"
 target_node = NodePath(".")
-actions = Array[ExtResource("2_e5301")]([SubResource("Resource_6310v"), SubResource("Resource_1iq3u"), SubResource("Resource_cbhwn")])
+actions = Array[ExtResource("2_e5301")]([SubResource("Resource_cbhwn"), SubResource("Resource_jqahe"), SubResource("Resource_qhwv1")])
 block_type = "event"
+personal_id = 1
 
-[sub_resource type="Resource" id="Resource_qhwv1"]
+[sub_resource type="Resource" id="Resource_lifsa"]
 script = ExtResource("2_e5301")
 action_id = "set_velocity_y"
 target_node = NodePath(".")
@@ -53,21 +62,23 @@ inputs = {
 "Y": "node.velocity.y+system.get_var(\"gravity\") * delta"
 }
 block_type = "action"
+personal_id = 7
 
-[sub_resource type="Resource" id="Resource_8fi06"]
+[sub_resource type="Resource" id="Resource_1tvq8"]
 script = ExtResource("3_6310v")
 condition_id = "is_on_floor"
 target_node = NodePath(".")
 negated = true
 block_type = "condition"
 
-[sub_resource type="Resource" id="Resource_lifsa"]
+[sub_resource type="Resource" id="Resource_rd6mx"]
 script = ExtResource("2_e5301")
 is_branch = true
 branch_type = "if"
-branch_condition = SubResource("Resource_8fi06")
-branch_actions = Array[ExtResource("2_e5301")]([SubResource("Resource_qhwv1")])
+branch_condition = SubResource("Resource_1tvq8")
+branch_actions = Array[ExtResource("2_e5301")]([SubResource("Resource_lifsa")])
 block_type = "action"
+personal_id = 6
 
 [sub_resource type="Resource" id="Resource_4pupr"]
 script = ExtResource("2_e5301")
@@ -77,12 +88,14 @@ inputs = {
 "Y": "n_jump_force"
 }
 block_type = "action"
+personal_id = 10
 
 [sub_resource type="Resource" id="Resource_rqf3r"]
 script = ExtResource("2_e5301")
 action_id = "play"
 target_node = NodePath("Jump")
 block_type = "action"
+personal_id = 11
 
 [sub_resource type="Resource" id="Resource_smre5"]
 script = ExtResource("3_6310v")
@@ -90,15 +103,16 @@ condition_id = "is_on_floor"
 target_node = NodePath(".")
 block_type = "condition"
 
-[sub_resource type="Resource" id="Resource_1tvq8"]
+[sub_resource type="Resource" id="Resource_ercbp"]
 script = ExtResource("2_e5301")
 is_branch = true
 branch_type = "if"
 branch_condition = SubResource("Resource_smre5")
 branch_actions = Array[ExtResource("2_e5301")]([SubResource("Resource_4pupr"), SubResource("Resource_rqf3r")])
 block_type = "action"
+personal_id = 9
 
-[sub_resource type="Resource" id="Resource_rd6mx"]
+[sub_resource type="Resource" id="Resource_1geuf"]
 script = ExtResource("3_6310v")
 condition_id = "is_key_pressed"
 target_node = NodePath("System")
@@ -107,15 +121,16 @@ inputs = {
 }
 block_type = "condition"
 
-[sub_resource type="Resource" id="Resource_ercbp"]
+[sub_resource type="Resource" id="Resource_ftren"]
 script = ExtResource("2_e5301")
 is_branch = true
 branch_type = "if"
-branch_condition = SubResource("Resource_rd6mx")
-branch_actions = Array[ExtResource("2_e5301")]([SubResource("Resource_1tvq8")])
+branch_condition = SubResource("Resource_1geuf")
+branch_actions = Array[ExtResource("2_e5301")]([SubResource("Resource_ercbp")])
 block_type = "action"
+personal_id = 8
 
-[sub_resource type="Resource" id="Resource_1geuf"]
+[sub_resource type="Resource" id="Resource_ogks2"]
 script = ExtResource("2_e5301")
 action_id = "get_input_axis_2way"
 target_node = NodePath("System")
@@ -125,8 +140,9 @@ inputs = {
 "Store In": "\"direction\""
 }
 block_type = "action"
+personal_id = 12
 
-[sub_resource type="Resource" id="Resource_ftren"]
+[sub_resource type="Resource" id="Resource_iv7s5"]
 script = ExtResource("2_e5301")
 action_id = "set_velocity_x"
 target_node = NodePath(".")
@@ -134,8 +150,9 @@ inputs = {
 "X": "direction * n_speed"
 }
 block_type = "action"
+personal_id = 14
 
-[sub_resource type="Resource" id="Resource_ogks2"]
+[sub_resource type="Resource" id="Resource_iqbv7"]
 script = ExtResource("3_6310v")
 condition_id = "compare_node_variable"
 target_node = NodePath(".")
@@ -146,15 +163,16 @@ inputs = {
 }
 block_type = "condition"
 
-[sub_resource type="Resource" id="Resource_iv7s5"]
+[sub_resource type="Resource" id="Resource_01p3u"]
 script = ExtResource("2_e5301")
 is_branch = true
 branch_type = "if"
-branch_condition = SubResource("Resource_ogks2")
-branch_actions = Array[ExtResource("2_e5301")]([SubResource("Resource_ftren")])
+branch_condition = SubResource("Resource_iqbv7")
+branch_actions = Array[ExtResource("2_e5301")]([SubResource("Resource_iv7s5")])
 block_type = "action"
+personal_id = 13
 
-[sub_resource type="Resource" id="Resource_iqbv7"]
+[sub_resource type="Resource" id="Resource_jtk1k"]
 script = ExtResource("2_e5301")
 action_id = "set_velocity_x"
 target_node = NodePath(".")
@@ -162,36 +180,40 @@ inputs = {
 "X": "move_toward(node.velocity.x,0,n_speed)"
 }
 block_type = "action"
+personal_id = 16
 
-[sub_resource type="Resource" id="Resource_01p3u"]
+[sub_resource type="Resource" id="Resource_7khp5"]
 script = ExtResource("2_e5301")
 is_branch = true
 branch_type = "else"
-branch_actions = Array[ExtResource("2_e5301")]([SubResource("Resource_iqbv7")])
+branch_actions = Array[ExtResource("2_e5301")]([SubResource("Resource_jtk1k")])
 block_type = "action"
+personal_id = 15
 
-[sub_resource type="Resource" id="Resource_jtk1k"]
+[sub_resource type="Resource" id="Resource_w3432"]
 script = ExtResource("2_e5301")
 action_id = "move_and_slide"
 target_node = NodePath(".")
 block_type = "action"
+personal_id = 17
 
-[sub_resource type="Resource" id="Resource_7khp5"]
+[sub_resource type="Resource" id="Resource_fwgt7"]
 script = ExtResource("1_iqjwq")
-block_id = "event_1778968209_2739151933"
+block_id = "event_1784484129_115748872"
 event_id = "on_process_physics"
 target_node = NodePath(".")
-actions = Array[ExtResource("2_e5301")]([SubResource("Resource_lifsa"), SubResource("Resource_ercbp"), SubResource("Resource_1geuf"), SubResource("Resource_iv7s5"), SubResource("Resource_01p3u"), SubResource("Resource_jtk1k")])
+actions = Array[ExtResource("2_e5301")]([SubResource("Resource_rd6mx"), SubResource("Resource_ftren"), SubResource("Resource_ogks2"), SubResource("Resource_01p3u"), SubResource("Resource_7khp5"), SubResource("Resource_w3432")])
 block_type = "event"
+personal_id = 5
 
-[sub_resource type="Resource" id="Resource_w3432"]
+[sub_resource type="Resource" id="Resource_toik8"]
 script = ExtResource("5_1iq3u")
 title = "Movement"
 color = Color(0.4105078, 0.58125, 0, 1)
-children = [SubResource("Resource_jqahe"), SubResource("Resource_7khp5")]
+children = [SubResource("Resource_8fi06"), SubResource("Resource_fwgt7")]
 block_type = "group"
 
-[sub_resource type="Resource" id="Resource_fwgt7"]
+[sub_resource type="Resource" id="Resource_g1hr8"]
 script = ExtResource("2_e5301")
 action_id = "set_flip_h"
 target_node = NodePath("AnimatedSprite2D")
@@ -199,8 +221,9 @@ inputs = {
 "Value": "true"
 }
 block_type = "action"
+personal_id = 21
 
-[sub_resource type="Resource" id="Resource_toik8"]
+[sub_resource type="Resource" id="Resource_i8xgt"]
 script = ExtResource("3_6310v")
 condition_id = "compare_node_variable"
 target_node = NodePath(".")
@@ -210,17 +233,19 @@ inputs = {
 "Value": "0"
 }
 block_type = "condition"
+personal_id = 20
 
-[sub_resource type="Resource" id="Resource_g1hr8"]
+[sub_resource type="Resource" id="Resource_dkghy"]
 script = ExtResource("1_iqjwq")
-block_id = "event_1778968209_1371975470"
+block_id = "event_1784484129_3631946293"
 event_id = "on_process_physics"
 target_node = NodePath(".")
-conditions = Array[ExtResource("3_6310v")]([SubResource("Resource_toik8")])
-actions = Array[ExtResource("2_e5301")]([SubResource("Resource_fwgt7")])
+conditions = Array[ExtResource("3_6310v")]([SubResource("Resource_i8xgt")])
+actions = Array[ExtResource("2_e5301")]([SubResource("Resource_g1hr8")])
 block_type = "event"
+personal_id = 19
 
-[sub_resource type="Resource" id="Resource_i8xgt"]
+[sub_resource type="Resource" id="Resource_0864s"]
 script = ExtResource("2_e5301")
 action_id = "set_flip_h"
 target_node = NodePath("AnimatedSprite2D")
@@ -228,8 +253,9 @@ inputs = {
 "Value": "false"
 }
 block_type = "action"
+personal_id = 24
 
-[sub_resource type="Resource" id="Resource_dkghy"]
+[sub_resource type="Resource" id="Resource_ja7sq"]
 script = ExtResource("3_6310v")
 condition_id = "compare_node_variable"
 target_node = NodePath(".")
@@ -239,29 +265,33 @@ inputs = {
 "Value": "0"
 }
 block_type = "condition"
+personal_id = 23
 
-[sub_resource type="Resource" id="Resource_0864s"]
+[sub_resource type="Resource" id="Resource_rcr8d"]
 script = ExtResource("1_iqjwq")
-block_id = "event_1778968209_3083873755"
+block_id = "event_1784484129_427685405"
 event_id = "on_process_physics"
 target_node = NodePath(".")
-conditions = Array[ExtResource("3_6310v")]([SubResource("Resource_dkghy")])
-actions = Array[ExtResource("2_e5301")]([SubResource("Resource_i8xgt")])
+conditions = Array[ExtResource("3_6310v")]([SubResource("Resource_ja7sq")])
+actions = Array[ExtResource("2_e5301")]([SubResource("Resource_0864s")])
 block_type = "event"
+personal_id = 22
 
-[sub_resource type="Resource" id="Resource_ja7sq"]
+[sub_resource type="Resource" id="Resource_y2uhx"]
 script = ExtResource("5_1iq3u")
 title = "Sets the direction of the player sprite to flip the sprite horizontally based on if the player is moving left or right."
 color = Color(0.16839236, 0.07305908, 0.4453125, 1)
-children = [SubResource("Resource_g1hr8"), SubResource("Resource_0864s")]
+children = [SubResource("Resource_dkghy"), SubResource("Resource_rcr8d")]
 block_type = "group"
+personal_id = 18
 
-[sub_resource type="Resource" id="Resource_rcr8d"]
+[sub_resource type="Resource" id="Resource_lvjr6"]
 script = ExtResource("1_6310v")
 text = "Player is not moving"
 block_type = "comment"
+personal_id = 26
 
-[sub_resource type="Resource" id="Resource_y2uhx"]
+[sub_resource type="Resource" id="Resource_1lc76"]
 script = ExtResource("2_e5301")
 action_id = "animatedsprite2d_play"
 target_node = NodePath("AnimatedSprite2D")
@@ -271,8 +301,9 @@ inputs = {
 "Name": "\"default\""
 }
 block_type = "action"
+personal_id = 30
 
-[sub_resource type="Resource" id="Resource_lvjr6"]
+[sub_resource type="Resource" id="Resource_7ahgf"]
 script = ExtResource("3_6310v")
 condition_id = "compare_node_variable"
 target_node = NodePath(".")
@@ -282,28 +313,32 @@ inputs = {
 "Value": "0"
 }
 block_type = "condition"
+personal_id = 28
 
-[sub_resource type="Resource" id="Resource_1lc76"]
+[sub_resource type="Resource" id="Resource_rfu3m"]
 script = ExtResource("3_6310v")
 condition_id = "only_once_when_looped"
 target_node = NodePath("System")
 block_type = "condition"
+personal_id = 29
 
-[sub_resource type="Resource" id="Resource_7ahgf"]
+[sub_resource type="Resource" id="Resource_hklvi"]
 script = ExtResource("1_iqjwq")
-block_id = "event_1778968209_3026241755"
+block_id = "event_1784484129_2171159729"
 event_id = "on_process_physics"
 target_node = NodePath(".")
-conditions = Array[ExtResource("3_6310v")]([SubResource("Resource_lvjr6"), SubResource("Resource_1lc76")])
-actions = Array[ExtResource("2_e5301")]([SubResource("Resource_y2uhx")])
+conditions = Array[ExtResource("3_6310v")]([SubResource("Resource_7ahgf"), SubResource("Resource_rfu3m")])
+actions = Array[ExtResource("2_e5301")]([SubResource("Resource_1lc76")])
 block_type = "event"
+personal_id = 27
 
-[sub_resource type="Resource" id="Resource_rfu3m"]
+[sub_resource type="Resource" id="Resource_olurx"]
 script = ExtResource("1_6310v")
 text = "Player is moving"
 block_type = "comment"
+personal_id = 31
 
-[sub_resource type="Resource" id="Resource_hklvi"]
+[sub_resource type="Resource" id="Resource_a558m"]
 script = ExtResource("2_e5301")
 action_id = "animatedsprite2d_play"
 target_node = NodePath("AnimatedSprite2D")
@@ -313,8 +348,9 @@ inputs = {
 "Name": "\"run\""
 }
 block_type = "action"
+personal_id = 35
 
-[sub_resource type="Resource" id="Resource_olurx"]
+[sub_resource type="Resource" id="Resource_8cdef"]
 script = ExtResource("3_6310v")
 condition_id = "compare_node_variable"
 target_node = NodePath(".")
@@ -324,32 +360,36 @@ inputs = {
 "Value": "0"
 }
 block_type = "condition"
+personal_id = 33
 
-[sub_resource type="Resource" id="Resource_a558m"]
+[sub_resource type="Resource" id="Resource_vco3e"]
 script = ExtResource("3_6310v")
 condition_id = "only_once_when_looped"
 target_node = NodePath("System")
 block_type = "condition"
+personal_id = 34
 
-[sub_resource type="Resource" id="Resource_8cdef"]
+[sub_resource type="Resource" id="Resource_msi1s"]
 script = ExtResource("1_iqjwq")
-block_id = "event_1778968209_2520809527"
+block_id = "event_1784484129_3646751925"
 event_id = "on_process_physics"
 target_node = NodePath(".")
-conditions = Array[ExtResource("3_6310v")]([SubResource("Resource_olurx"), SubResource("Resource_a558m")])
-actions = Array[ExtResource("2_e5301")]([SubResource("Resource_hklvi")])
+conditions = Array[ExtResource("3_6310v")]([SubResource("Resource_8cdef"), SubResource("Resource_vco3e")])
+actions = Array[ExtResource("2_e5301")]([SubResource("Resource_a558m")])
 block_type = "event"
+personal_id = 32
 
-[sub_resource type="Resource" id="Resource_vco3e"]
+[sub_resource type="Resource" id="Resource_5glc6"]
 script = ExtResource("5_1iq3u")
 title = "Control animations"
 color = Color(0.38236463, 0.2642212, 0.7515625, 1)
-children = [SubResource("Resource_rcr8d"), SubResource("Resource_7ahgf"), SubResource("Resource_rfu3m"), SubResource("Resource_8cdef")]
+children = [SubResource("Resource_lvjr6"), SubResource("Resource_hklvi"), SubResource("Resource_olurx"), SubResource("Resource_msi1s")]
 block_type = "group"
+personal_id = 25
 
 [resource]
 script = ExtResource("4_1iq3u")
-groups = Array[ExtResource("5_1iq3u")]([SubResource("Resource_w3432"), SubResource("Resource_ja7sq"), SubResource("Resource_vco3e")])
+groups = Array[ExtResource("5_1iq3u")]([SubResource("Resource_toik8"), SubResource("Resource_y2uhx"), SubResource("Resource_5glc6")])
 item_order = Array[Dictionary]([{
 "index": 0,
 "type": "group"
@@ -360,3 +400,4 @@ item_order = Array[Dictionary]([{
 "index": 2,
 "type": "group"
 }])
+_id_assigner = SubResource("Resource_1iq3u")

--- a/addons/flowkit/saved/event_sheet/6104984665772134237.tres
+++ b/addons/flowkit/saved/event_sheet/6104984665772134237.tres
@@ -1,13 +1,18 @@
 [gd_resource type="Resource" script_class="FKEventSheet" format=3 uid="uid://dv106octff6l4"]
 
 [ext_resource type="Script" uid="uid://b1y3c8rnt2rcg" path="res://addons/flowkit/runtime/Units/comment_unit.gd" id="1_1axor"]
+[ext_resource type="Script" uid="uid://bfctyysd72b6p" path="res://addons/flowkit/runtime/id_assigner.gd" id="1_ju1rn"]
 [ext_resource type="Script" uid="uid://bxdhylwvr4osy" path="res://addons/flowkit/runtime/Units/event_block.gd" id="2_ju1rn"]
 [ext_resource type="Script" uid="uid://bwbi0utcwmxwf" path="res://addons/flowkit/runtime/Units/action_unit.gd" id="3_5poua"]
 [ext_resource type="Script" uid="uid://bmaxurgrsv4ct" path="res://addons/flowkit/runtime/Units/condition_unit.gd" id="4_ayedq"]
 [ext_resource type="Script" path="res://addons/flowkit/runtime/Units/group_unit.gd" id="5_np8on"]
 [ext_resource type="Script" uid="uid://bumsyiqkp46l1" path="res://addons/flowkit/resources/event_sheet.gd" id="6_v1ajb"]
 
-[sub_resource type="Resource" id="Resource_1axor"]
+[sub_resource type="Resource" id="Resource_ju1rn"]
+script = ExtResource("1_ju1rn")
+_latest_id_given = 7
+
+[sub_resource type="Resource" id="Resource_5poua"]
 script = ExtResource("3_5poua")
 action_id = "set_window_size"
 target_node = NodePath("System")
@@ -16,8 +21,9 @@ inputs = {
 "Width": "1280"
 }
 block_type = "action"
+personal_id = 1
 
-[sub_resource type="Resource" id="Resource_ju1rn"]
+[sub_resource type="Resource" id="Resource_ayedq"]
 script = ExtResource("3_5poua")
 action_id = "set_window_mode"
 target_node = NodePath("System")
@@ -25,8 +31,9 @@ inputs = {
 "Mode": "\"windowed\""
 }
 block_type = "action"
+personal_id = 2
 
-[sub_resource type="Resource" id="Resource_5poua"]
+[sub_resource type="Resource" id="Resource_np8on"]
 script = ExtResource("3_5poua")
 action_id = "Print Message"
 target_node = NodePath(".")
@@ -35,8 +42,9 @@ inputs = {
 "Message": "\"This is a message printed with the default color.\""
 }
 block_type = "action"
+personal_id = 3
 
-[sub_resource type="Resource" id="Resource_ayedq"]
+[sub_resource type="Resource" id="Resource_v1ajb"]
 script = ExtResource("3_5poua")
 action_id = "Print Message"
 target_node = NodePath(".")
@@ -45,8 +53,9 @@ inputs = {
 "message": "\"This is a message printed in red text.\""
 }
 block_type = "action"
+personal_id = 4
 
-[sub_resource type="Resource" id="Resource_np8on"]
+[sub_resource type="Resource" id="Resource_e46t1"]
 script = ExtResource("3_5poua")
 action_id = "Print Message"
 target_node = NodePath(".")
@@ -55,8 +64,9 @@ inputs = {
 "message": "\"[i]This is a message printed in green italicized text.[/i]\""
 }
 block_type = "action"
+personal_id = 5
 
-[sub_resource type="Resource" id="Resource_v1ajb"]
+[sub_resource type="Resource" id="Resource_5spa6"]
 script = ExtResource("3_5poua")
 action_id = "Print Message"
 target_node = NodePath(".")
@@ -65,8 +75,9 @@ inputs = {
 "message": "\"[b]Yellow bold text.[/b]\""
 }
 block_type = "action"
+personal_id = 6
 
-[sub_resource type="Resource" id="Resource_e46t1"]
+[sub_resource type="Resource" id="Resource_a8al3"]
 script = ExtResource("3_5poua")
 action_id = "Print Message"
 target_node = NodePath(".")
@@ -75,19 +86,21 @@ inputs = {
 "message": "\"[wave][color=#FF0000]W[/color][color=#FF5500]a[/color][color=#FFAA00]v[/color][color=#FFFF00]y[/color] [color=#54FF00]r[/color][color=#00FF00]a[/color][color=#00FF55]i[/color][color=#00FFAA]n[/color][color=#00FEFF]b[/color][color=#00A9FF]o[/color][color=#0054FF]w[/color] [color=#5500FF]t[/color][color=#AA00FF]e[/color][color=#FF00FE]x[/color][color=#FF00AA]t[/color][color=#FF0054]![/color][/wave]\""
 }
 block_type = "action"
+personal_id = 7
 
-[sub_resource type="Resource" id="Resource_5spa6"]
+[sub_resource type="Resource" id="Resource_xle1s"]
 script = ExtResource("2_ju1rn")
-block_id = "event_1778579360_2640092096"
+block_id = "event_1784484136_4040628200"
 event_id = "on_ready"
 target_node = NodePath(".")
-actions = Array[ExtResource("3_5poua")]([SubResource("Resource_1axor"), SubResource("Resource_ju1rn"), SubResource("Resource_5poua"), SubResource("Resource_ayedq"), SubResource("Resource_np8on"), SubResource("Resource_v1ajb"), SubResource("Resource_e46t1")])
+actions = Array[ExtResource("3_5poua")]([SubResource("Resource_5poua"), SubResource("Resource_ayedq"), SubResource("Resource_np8on"), SubResource("Resource_v1ajb"), SubResource("Resource_e46t1"), SubResource("Resource_5spa6"), SubResource("Resource_a8al3")])
 block_type = "event"
 
 [resource]
 script = ExtResource("6_v1ajb")
-events = Array[ExtResource("2_ju1rn")]([SubResource("Resource_5spa6")])
+events = Array[ExtResource("2_ju1rn")]([SubResource("Resource_xle1s")])
 item_order = Array[Dictionary]([{
 "index": 0,
 "type": "event"
 }])
+_id_assigner = SubResource("Resource_ju1rn")

--- a/addons/flowkit/saved/event_sheet/6180251268833091125.tres
+++ b/addons/flowkit/saved/event_sheet/6180251268833091125.tres
@@ -1,5 +1,6 @@
 [gd_resource type="Resource" script_class="FKEventSheet" format=3 uid="uid://uo45usge3b6k"]
 
+[ext_resource type="Script" uid="uid://bfctyysd72b6p" path="res://addons/flowkit/runtime/id_assigner.gd" id="1_s7o4u"]
 [ext_resource type="Script" uid="uid://b1y3c8rnt2rcg" path="res://addons/flowkit/runtime/Units/comment_unit.gd" id="1_t5adf"]
 [ext_resource type="Script" uid="uid://bxdhylwvr4osy" path="res://addons/flowkit/runtime/Units/event_block.gd" id="2_s7o4u"]
 [ext_resource type="Script" uid="uid://bwbi0utcwmxwf" path="res://addons/flowkit/runtime/Units/action_unit.gd" id="3_ytm5k"]
@@ -7,12 +8,17 @@
 [ext_resource type="Script" path="res://addons/flowkit/runtime/Units/group_unit.gd" id="5_iynvq"]
 [ext_resource type="Script" uid="uid://bumsyiqkp46l1" path="res://addons/flowkit/resources/event_sheet.gd" id="6_1sc5p"]
 
-[sub_resource type="Resource" id="Resource_t5adf"]
+[sub_resource type="Resource" id="Resource_s7o4u"]
+script = ExtResource("1_s7o4u")
+_latest_id_given = 17
+
+[sub_resource type="Resource" id="Resource_ytm5k"]
 script = ExtResource("1_t5adf")
 text = "Can make for good reference for a pre-title sequence"
 block_type = "comment"
+personal_id = 17
 
-[sub_resource type="Resource" id="Resource_s7o4u"]
+[sub_resource type="Resource" id="Resource_rm0fh"]
 script = ExtResource("3_ytm5k")
 action_id = "set_window_mode"
 target_node = NodePath("System")
@@ -20,8 +26,9 @@ inputs = {
 "Mode": "\"windowed\""
 }
 block_type = "action"
+personal_id = 2
 
-[sub_resource type="Resource" id="Resource_ytm5k"]
+[sub_resource type="Resource" id="Resource_iynvq"]
 script = ExtResource("3_ytm5k")
 action_id = "set_window_size"
 target_node = NodePath("System")
@@ -30,8 +37,9 @@ inputs = {
 "Width": "1280"
 }
 block_type = "action"
+personal_id = 3
 
-[sub_resource type="Resource" id="Resource_rm0fh"]
+[sub_resource type="Resource" id="Resource_1sc5p"]
 script = ExtResource("3_ytm5k")
 action_id = "Fade Modulate Color"
 target_node = NodePath("CanvasLayer/FlowkitLogo")
@@ -43,8 +51,9 @@ inputs = {
 "Wait For Finish": ""
 }
 block_type = "action"
+personal_id = 4
 
-[sub_resource type="Resource" id="Resource_iynvq"]
+[sub_resource type="Resource" id="Resource_ejtba"]
 script = ExtResource("3_ytm5k")
 action_id = "Fade Modulate Color"
 target_node = NodePath("CanvasLayer/GodotLogo")
@@ -56,8 +65,9 @@ inputs = {
 "Wait For Finish": ""
 }
 block_type = "action"
+personal_id = 5
 
-[sub_resource type="Resource" id="Resource_1sc5p"]
+[sub_resource type="Resource" id="Resource_kbegb"]
 script = ExtResource("3_ytm5k")
 action_id = "Fade Modulate Color"
 target_node = NodePath("CanvasLayer/StudioLogo")
@@ -69,8 +79,9 @@ inputs = {
 "Wait For Finish": "true"
 }
 block_type = "action"
+personal_id = 6
 
-[sub_resource type="Resource" id="Resource_ejtba"]
+[sub_resource type="Resource" id="Resource_2i0f5"]
 script = ExtResource("3_ytm5k")
 action_id = "Fade Color"
 target_node = NodePath("CanvasLayer/CoversScreen")
@@ -82,47 +93,13 @@ inputs = {
 "Wait For Finish": ""
 }
 block_type = "action"
-
-[sub_resource type="Resource" id="Resource_kbegb"]
-script = ExtResource("3_ytm5k")
-action_id = "Fade Modulate Color"
-target_node = NodePath("CanvasLayer/StudioLogo")
-inputs = {
-"Alpha": "100",
-"Alpha Only": "true",
-"Duration": "2",
-"Target Color": "",
-"Wait For Finish": ""
-}
-block_type = "action"
-
-[sub_resource type="Resource" id="Resource_2i0f5"]
-script = ExtResource("3_ytm5k")
-action_id = "Wait For Input"
-target_node = NodePath("System")
-inputs = {
-"Input Binding Name": "\"ui_accept\""
-}
-block_type = "action"
+personal_id = 7
 
 [sub_resource type="Resource" id="Resource_8saiw"]
 script = ExtResource("3_ytm5k")
 action_id = "Fade Modulate Color"
 target_node = NodePath("CanvasLayer/StudioLogo")
 inputs = {
-"Alpha": "0",
-"Alpha Only": "true",
-"Duration": "2",
-"Target Color": "",
-"Wait For Finish": ""
-}
-block_type = "action"
-
-[sub_resource type="Resource" id="Resource_vta5f"]
-script = ExtResource("3_ytm5k")
-action_id = "Fade Modulate Color"
-target_node = NodePath("CanvasLayer/GodotLogo")
-inputs = {
 "Alpha": "100",
 "Alpha Only": "true",
 "Duration": "2",
@@ -130,8 +107,9 @@ inputs = {
 "Wait For Finish": ""
 }
 block_type = "action"
+personal_id = 8
 
-[sub_resource type="Resource" id="Resource_a77t4"]
+[sub_resource type="Resource" id="Resource_vta5f"]
 script = ExtResource("3_ytm5k")
 action_id = "Wait For Input"
 target_node = NodePath("System")
@@ -139,12 +117,51 @@ inputs = {
 "Input Binding Name": "\"ui_accept\""
 }
 block_type = "action"
+personal_id = 9
+
+[sub_resource type="Resource" id="Resource_a77t4"]
+script = ExtResource("3_ytm5k")
+action_id = "Fade Modulate Color"
+target_node = NodePath("CanvasLayer/StudioLogo")
+inputs = {
+"Alpha": "0",
+"Alpha Only": "true",
+"Duration": "2",
+"Target Color": "",
+"Wait For Finish": ""
+}
+block_type = "action"
+personal_id = 10
 
 [sub_resource type="Resource" id="Resource_g2c3u"]
 script = ExtResource("3_ytm5k")
 action_id = "Fade Modulate Color"
 target_node = NodePath("CanvasLayer/GodotLogo")
 inputs = {
+"Alpha": "100",
+"Alpha Only": "true",
+"Duration": "2",
+"Target Color": "",
+"Wait For Finish": ""
+}
+block_type = "action"
+personal_id = 11
+
+[sub_resource type="Resource" id="Resource_li7lq"]
+script = ExtResource("3_ytm5k")
+action_id = "Wait For Input"
+target_node = NodePath("System")
+inputs = {
+"Input Binding Name": "\"ui_accept\""
+}
+block_type = "action"
+personal_id = 12
+
+[sub_resource type="Resource" id="Resource_b3hw7"]
+script = ExtResource("3_ytm5k")
+action_id = "Fade Modulate Color"
+target_node = NodePath("CanvasLayer/GodotLogo")
+inputs = {
 "Alpha": "0",
 "Alpha Only": "true",
 "Duration": "2",
@@ -152,8 +169,9 @@ inputs = {
 "Wait For Finish": ""
 }
 block_type = "action"
+personal_id = 13
 
-[sub_resource type="Resource" id="Resource_li7lq"]
+[sub_resource type="Resource" id="Resource_1qadt"]
 script = ExtResource("3_ytm5k")
 action_id = "Fade Modulate Color"
 target_node = NodePath("CanvasLayer/FlowkitLogo")
@@ -165,8 +183,9 @@ inputs = {
 "Wait For Finish": ""
 }
 block_type = "action"
+personal_id = 14
 
-[sub_resource type="Resource" id="Resource_b3hw7"]
+[sub_resource type="Resource" id="Resource_cdt56"]
 script = ExtResource("3_ytm5k")
 action_id = "Wait For Input"
 target_node = NodePath("System")
@@ -174,8 +193,9 @@ inputs = {
 "Input Binding Name": "\"ui_accept\""
 }
 block_type = "action"
+personal_id = 15
 
-[sub_resource type="Resource" id="Resource_1qadt"]
+[sub_resource type="Resource" id="Resource_ioy8n"]
 script = ExtResource("3_ytm5k")
 action_id = "Fade Modulate Color"
 target_node = NodePath("CanvasLayer/FlowkitLogo")
@@ -187,19 +207,20 @@ inputs = {
 "Wait For Finish": ""
 }
 block_type = "action"
+personal_id = 16
 
-[sub_resource type="Resource" id="Resource_cdt56"]
+[sub_resource type="Resource" id="Resource_jon7v"]
 script = ExtResource("2_s7o4u")
-block_id = "event_1775569737_3692921711"
+block_id = "event_1784483670_1262272698"
 event_id = "on_ready"
 target_node = NodePath("Timers")
-actions = Array[ExtResource("3_ytm5k")]([SubResource("Resource_s7o4u"), SubResource("Resource_ytm5k"), SubResource("Resource_rm0fh"), SubResource("Resource_iynvq"), SubResource("Resource_1sc5p"), SubResource("Resource_ejtba"), SubResource("Resource_kbegb"), SubResource("Resource_2i0f5"), SubResource("Resource_8saiw"), SubResource("Resource_vta5f"), SubResource("Resource_a77t4"), SubResource("Resource_g2c3u"), SubResource("Resource_li7lq"), SubResource("Resource_b3hw7"), SubResource("Resource_1qadt")])
+actions = Array[ExtResource("3_ytm5k")]([SubResource("Resource_rm0fh"), SubResource("Resource_iynvq"), SubResource("Resource_1sc5p"), SubResource("Resource_ejtba"), SubResource("Resource_kbegb"), SubResource("Resource_2i0f5"), SubResource("Resource_8saiw"), SubResource("Resource_vta5f"), SubResource("Resource_a77t4"), SubResource("Resource_g2c3u"), SubResource("Resource_li7lq"), SubResource("Resource_b3hw7"), SubResource("Resource_1qadt"), SubResource("Resource_cdt56"), SubResource("Resource_ioy8n")])
 block_type = "event"
 
 [resource]
 script = ExtResource("6_1sc5p")
-events = Array[ExtResource("2_s7o4u")]([SubResource("Resource_cdt56")])
-comments = Array[ExtResource("1_t5adf")]([SubResource("Resource_t5adf")])
+events = Array[ExtResource("2_s7o4u")]([SubResource("Resource_jon7v")])
+comments = Array[ExtResource("1_t5adf")]([SubResource("Resource_ytm5k")])
 item_order = Array[Dictionary]([{
 "index": 0,
 "type": "comment"
@@ -207,3 +228,4 @@ item_order = Array[Dictionary]([{
 "index": 0,
 "type": "event"
 }])
+_id_assigner = SubResource("Resource_s7o4u")

--- a/addons/flowkit/saved/event_sheet/7830454191141003914.tres
+++ b/addons/flowkit/saved/event_sheet/7830454191141003914.tres
@@ -1,18 +1,24 @@
 [gd_resource type="Resource" script_class="FKEventSheet" format=3 uid="uid://bude0li5knaft"]
 
 [ext_resource type="Script" uid="uid://b1y3c8rnt2rcg" path="res://addons/flowkit/runtime/Units/comment_unit.gd" id="1_e8buc"]
+[ext_resource type="Script" uid="uid://bfctyysd72b6p" path="res://addons/flowkit/runtime/id_assigner.gd" id="1_uoxok"]
 [ext_resource type="Script" uid="uid://bxdhylwvr4osy" path="res://addons/flowkit/runtime/Units/event_block.gd" id="2_uoxok"]
 [ext_resource type="Script" uid="uid://bwbi0utcwmxwf" path="res://addons/flowkit/runtime/Units/action_unit.gd" id="3_j21vh"]
 [ext_resource type="Script" uid="uid://bmaxurgrsv4ct" path="res://addons/flowkit/runtime/Units/condition_unit.gd" id="4_s7nm7"]
 [ext_resource type="Script" path="res://addons/flowkit/runtime/Units/group_unit.gd" id="5_i1nl3"]
 [ext_resource type="Script" uid="uid://bumsyiqkp46l1" path="res://addons/flowkit/resources/event_sheet.gd" id="6_rpy5k"]
 
-[sub_resource type="Resource" id="Resource_df7pu"]
+[sub_resource type="Resource" id="Resource_uoxok"]
+script = ExtResource("1_uoxok")
+_latest_id_given = 70
+
+[sub_resource type="Resource" id="Resource_j21vh"]
 script = ExtResource("1_e8buc")
 text = "Yep, it's Godot trivia!"
 block_type = "comment"
+personal_id = 70
 
-[sub_resource type="Resource" id="Resource_uoxok"]
+[sub_resource type="Resource" id="Resource_emcdn"]
 script = ExtResource("3_j21vh")
 action_id = "set_window_mode"
 target_node = NodePath("System")
@@ -20,8 +26,9 @@ inputs = {
 "Mode": "\"windowed\""
 }
 block_type = "action"
+personal_id = 1
 
-[sub_resource type="Resource" id="Resource_j21vh"]
+[sub_resource type="Resource" id="Resource_ulxaw"]
 script = ExtResource("3_j21vh")
 action_id = "set_window_size"
 target_node = NodePath("System")
@@ -30,8 +37,9 @@ inputs = {
 "Width": "1280"
 }
 block_type = "action"
+personal_id = 2
 
-[sub_resource type="Resource" id="Resource_emcdn"]
+[sub_resource type="Resource" id="Resource_rpy5k"]
 script = ExtResource("3_j21vh")
 action_id = "Wait For Frames"
 target_node = NodePath("System")
@@ -39,8 +47,9 @@ inputs = {
 "Frame Count": "1"
 }
 block_type = "action"
+personal_id = 3
 
-[sub_resource type="Resource" id="Resource_ulxaw"]
+[sub_resource type="Resource" id="Resource_efrgi"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -49,8 +58,9 @@ inputs = {
 "Value": "\"[center]When was Godot 4.3\\nfirst released?[/center]\""
 }
 block_type = "action"
+personal_id = 4
 
-[sub_resource type="Resource" id="Resource_rpy5k"]
+[sub_resource type="Resource" id="Resource_e6bne"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -59,8 +69,9 @@ inputs = {
 "Value": "\"[center]What license is Godot released under?[/center]\""
 }
 block_type = "action"
+personal_id = 5
 
-[sub_resource type="Resource" id="Resource_efrgi"]
+[sub_resource type="Resource" id="Resource_1h0yk"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -69,8 +80,9 @@ inputs = {
 "Value": "\"[center]Which Godot version was the first to officially support C#?[/center]\""
 }
 block_type = "action"
+personal_id = 6
 
-[sub_resource type="Resource" id="Resource_e6bne"]
+[sub_resource type="Resource" id="Resource_7gjgi"]
 script = ExtResource("3_j21vh")
 action_id = "Set Text"
 target_node = NodePath("DisplaysQuestion/QuestionText")
@@ -78,8 +90,9 @@ inputs = {
 "New Text": "system.get_var(\"firstQuestion\")"
 }
 block_type = "action"
+personal_id = 7
 
-[sub_resource type="Resource" id="Resource_1h0yk"]
+[sub_resource type="Resource" id="Resource_njo67"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -88,8 +101,9 @@ inputs = {
 "Value": "\"August 14, 2024\""
 }
 block_type = "action"
+personal_id = 8
 
-[sub_resource type="Resource" id="Resource_7gjgi"]
+[sub_resource type="Resource" id="Resource_7p70r"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -98,8 +112,9 @@ inputs = {
 "Value": "\"July 3rd, 2024\""
 }
 block_type = "action"
+personal_id = 9
 
-[sub_resource type="Resource" id="Resource_njo67"]
+[sub_resource type="Resource" id="Resource_jl3cs"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -108,8 +123,9 @@ inputs = {
 "Value": "\"March 1st, 2024\""
 }
 block_type = "action"
+personal_id = 10
 
-[sub_resource type="Resource" id="Resource_7p70r"]
+[sub_resource type="Resource" id="Resource_y38jp"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -118,8 +134,9 @@ inputs = {
 "Value": "\"July 28th, 2024\""
 }
 block_type = "action"
+personal_id = 11
 
-[sub_resource type="Resource" id="Resource_jl3cs"]
+[sub_resource type="Resource" id="Resource_6grxg"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -128,8 +145,9 @@ inputs = {
 "Value": "system.get_var(\"firstQuestionFirstAnswer\")"
 }
 block_type = "action"
+personal_id = 12
 
-[sub_resource type="Resource" id="Resource_y38jp"]
+[sub_resource type="Resource" id="Resource_jpbjx"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -138,8 +156,9 @@ inputs = {
 "Value": "system.get_var(\"firstQuestionFirstAnswer\")"
 }
 block_type = "action"
+personal_id = 13
 
-[sub_resource type="Resource" id="Resource_6grxg"]
+[sub_resource type="Resource" id="Resource_ewbs2"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -148,8 +167,9 @@ inputs = {
 "Value": "system.get_var(\"firstQuestionSecondAnswer\")"
 }
 block_type = "action"
+personal_id = 14
 
-[sub_resource type="Resource" id="Resource_jpbjx"]
+[sub_resource type="Resource" id="Resource_7e0ye"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -158,8 +178,9 @@ inputs = {
 "Value": "system.get_var(\"firstQuestionThirdAnswer\")"
 }
 block_type = "action"
+personal_id = 15
 
-[sub_resource type="Resource" id="Resource_ewbs2"]
+[sub_resource type="Resource" id="Resource_yayi7"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -168,8 +189,9 @@ inputs = {
 "Value": "system.get_var(\"firstQuestionFourthAnswer\")"
 }
 block_type = "action"
+personal_id = 16
 
-[sub_resource type="Resource" id="Resource_7e0ye"]
+[sub_resource type="Resource" id="Resource_4t33x"]
 script = ExtResource("3_j21vh")
 action_id = "Set Text"
 target_node = NodePath("HoldsAnswers/FirstAnswerButton")
@@ -177,8 +199,9 @@ inputs = {
 "New Text": "system.get_var(\"firstAnswerText\")"
 }
 block_type = "action"
+personal_id = 17
 
-[sub_resource type="Resource" id="Resource_yayi7"]
+[sub_resource type="Resource" id="Resource_3wu3y"]
 script = ExtResource("3_j21vh")
 action_id = "Set Text"
 target_node = NodePath("HoldsAnswers/SecondAnswerButton")
@@ -186,8 +209,9 @@ inputs = {
 "New Text": "system.get_var(\"secondAnswerText\")"
 }
 block_type = "action"
+personal_id = 18
 
-[sub_resource type="Resource" id="Resource_4t33x"]
+[sub_resource type="Resource" id="Resource_8wvsr"]
 script = ExtResource("3_j21vh")
 action_id = "Set Text"
 target_node = NodePath("HoldsAnswers/ThirdAnswerButton")
@@ -195,8 +219,9 @@ inputs = {
 "New Text": "system.get_var(\"thirdAnswerText\")"
 }
 block_type = "action"
+personal_id = 19
 
-[sub_resource type="Resource" id="Resource_3wu3y"]
+[sub_resource type="Resource" id="Resource_apwru"]
 script = ExtResource("3_j21vh")
 action_id = "Set Text"
 target_node = NodePath("HoldsAnswers/FourthAnswerButton")
@@ -204,8 +229,9 @@ inputs = {
 "New Text": "system.get_var(\"fourthAnswerText\")"
 }
 block_type = "action"
+personal_id = 20
 
-[sub_resource type="Resource" id="Resource_8wvsr"]
+[sub_resource type="Resource" id="Resource_yrydo"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -214,8 +240,9 @@ inputs = {
 "Value": "system.get_var(\"firstQuestionFirstAnswer\")"
 }
 block_type = "action"
+personal_id = 21
 
-[sub_resource type="Resource" id="Resource_apwru"]
+[sub_resource type="Resource" id="Resource_hlcqt"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -224,8 +251,9 @@ inputs = {
 "Value": "\"Apache 2.0\""
 }
 block_type = "action"
+personal_id = 22
 
-[sub_resource type="Resource" id="Resource_yrydo"]
+[sub_resource type="Resource" id="Resource_cfel1"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -234,8 +262,9 @@ inputs = {
 "Value": "\"Zlib License\""
 }
 block_type = "action"
+personal_id = 23
 
-[sub_resource type="Resource" id="Resource_hlcqt"]
+[sub_resource type="Resource" id="Resource_fe1w8"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -244,8 +273,9 @@ inputs = {
 "Value": "\"MIT\""
 }
 block_type = "action"
+personal_id = 24
 
-[sub_resource type="Resource" id="Resource_cfel1"]
+[sub_resource type="Resource" id="Resource_e0fgu"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -254,8 +284,9 @@ inputs = {
 "Value": "\"Creative Commons BY‑SA\""
 }
 block_type = "action"
+personal_id = 25
 
-[sub_resource type="Resource" id="Resource_fe1w8"]
+[sub_resource type="Resource" id="Resource_t47qt"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -264,8 +295,9 @@ inputs = {
 "Value": "system.get_var(\"secondQuestionThirdAnswer\")"
 }
 block_type = "action"
+personal_id = 26
 
-[sub_resource type="Resource" id="Resource_e0fgu"]
+[sub_resource type="Resource" id="Resource_icjx7"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -274,8 +306,9 @@ inputs = {
 "Value": "\"2.1\""
 }
 block_type = "action"
+personal_id = 27
 
-[sub_resource type="Resource" id="Resource_t47qt"]
+[sub_resource type="Resource" id="Resource_o3aem"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -284,8 +317,9 @@ inputs = {
 "Value": "\"4.0\""
 }
 block_type = "action"
+personal_id = 28
 
-[sub_resource type="Resource" id="Resource_icjx7"]
+[sub_resource type="Resource" id="Resource_bmqy2"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -294,8 +328,9 @@ inputs = {
 "Value": "\"3.5\""
 }
 block_type = "action"
+personal_id = 29
 
-[sub_resource type="Resource" id="Resource_o3aem"]
+[sub_resource type="Resource" id="Resource_7fkax"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -304,8 +339,9 @@ inputs = {
 "Value": "\"3.0\""
 }
 block_type = "action"
+personal_id = 30
 
-[sub_resource type="Resource" id="Resource_bmqy2"]
+[sub_resource type="Resource" id="Resource_f6ogq"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -314,8 +350,9 @@ inputs = {
 "Value": "system.get_var(\"thirdQuestionFourthAnswer\")"
 }
 block_type = "action"
+personal_id = 31
 
-[sub_resource type="Resource" id="Resource_7fkax"]
+[sub_resource type="Resource" id="Resource_gajsv"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -324,8 +361,9 @@ inputs = {
 "Value": "system.get_var(\"firstQuestionCorrectAnswer\")"
 }
 block_type = "action"
+personal_id = 32
 
-[sub_resource type="Resource" id="Resource_f6ogq"]
+[sub_resource type="Resource" id="Resource_e5g1r"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -334,8 +372,9 @@ inputs = {
 "Value": "system.get_var(\"firstQuestionFirstAnswer\")"
 }
 block_type = "action"
+personal_id = 33
 
-[sub_resource type="Resource" id="Resource_gajsv"]
+[sub_resource type="Resource" id="Resource_3pq7a"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -344,8 +383,9 @@ inputs = {
 "Value": "system.get_var(\"firstQuestionSecondAnswer\")"
 }
 block_type = "action"
+personal_id = 34
 
-[sub_resource type="Resource" id="Resource_e5g1r"]
+[sub_resource type="Resource" id="Resource_e3r8u"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -354,16 +394,17 @@ inputs = {
 "Value": "0"
 }
 block_type = "action"
+personal_id = 35
 
-[sub_resource type="Resource" id="Resource_3pq7a"]
+[sub_resource type="Resource" id="Resource_vvbgy"]
 script = ExtResource("2_uoxok")
-block_id = "event_1778579460_153282279"
+block_id = "event_1784483657_3848322284"
 event_id = "on_ready"
 target_node = NodePath(".")
-actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_uoxok"), SubResource("Resource_j21vh"), SubResource("Resource_emcdn"), SubResource("Resource_ulxaw"), SubResource("Resource_rpy5k"), SubResource("Resource_efrgi"), SubResource("Resource_e6bne"), SubResource("Resource_1h0yk"), SubResource("Resource_7gjgi"), SubResource("Resource_njo67"), SubResource("Resource_7p70r"), SubResource("Resource_jl3cs"), SubResource("Resource_y38jp"), SubResource("Resource_6grxg"), SubResource("Resource_jpbjx"), SubResource("Resource_ewbs2"), SubResource("Resource_7e0ye"), SubResource("Resource_yayi7"), SubResource("Resource_4t33x"), SubResource("Resource_3wu3y"), SubResource("Resource_8wvsr"), SubResource("Resource_apwru"), SubResource("Resource_yrydo"), SubResource("Resource_hlcqt"), SubResource("Resource_cfel1"), SubResource("Resource_fe1w8"), SubResource("Resource_e0fgu"), SubResource("Resource_t47qt"), SubResource("Resource_icjx7"), SubResource("Resource_o3aem"), SubResource("Resource_bmqy2"), SubResource("Resource_7fkax"), SubResource("Resource_f6ogq"), SubResource("Resource_gajsv"), SubResource("Resource_e5g1r")])
+actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_emcdn"), SubResource("Resource_ulxaw"), SubResource("Resource_rpy5k"), SubResource("Resource_efrgi"), SubResource("Resource_e6bne"), SubResource("Resource_1h0yk"), SubResource("Resource_7gjgi"), SubResource("Resource_njo67"), SubResource("Resource_7p70r"), SubResource("Resource_jl3cs"), SubResource("Resource_y38jp"), SubResource("Resource_6grxg"), SubResource("Resource_jpbjx"), SubResource("Resource_ewbs2"), SubResource("Resource_7e0ye"), SubResource("Resource_yayi7"), SubResource("Resource_4t33x"), SubResource("Resource_3wu3y"), SubResource("Resource_8wvsr"), SubResource("Resource_apwru"), SubResource("Resource_yrydo"), SubResource("Resource_hlcqt"), SubResource("Resource_cfel1"), SubResource("Resource_fe1w8"), SubResource("Resource_e0fgu"), SubResource("Resource_t47qt"), SubResource("Resource_icjx7"), SubResource("Resource_o3aem"), SubResource("Resource_bmqy2"), SubResource("Resource_7fkax"), SubResource("Resource_f6ogq"), SubResource("Resource_gajsv"), SubResource("Resource_e5g1r"), SubResource("Resource_3pq7a"), SubResource("Resource_e3r8u")])
 block_type = "event"
 
-[sub_resource type="Resource" id="Resource_e3r8u"]
+[sub_resource type="Resource" id="Resource_x3kut"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -372,8 +413,9 @@ inputs = {
 "Value": "system.get_var(\"firstAnswerText\")"
 }
 block_type = "action"
+personal_id = 37
 
-[sub_resource type="Resource" id="Resource_vvbgy"]
+[sub_resource type="Resource" id="Resource_2q5cv"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -382,14 +424,16 @@ inputs = {
 "Value": "system.get_var(\"correctAnswerCount\") + 1"
 }
 block_type = "action"
+personal_id = 39
 
-[sub_resource type="Resource" id="Resource_x3kut"]
+[sub_resource type="Resource" id="Resource_4rioj"]
 script = ExtResource("3_j21vh")
 action_id = "play"
 target_node = NodePath("CorrectVoiceClip")
 block_type = "action"
+personal_id = 40
 
-[sub_resource type="Resource" id="Resource_2q5cv"]
+[sub_resource type="Resource" id="Resource_cpo3s"]
 script = ExtResource("4_s7nm7")
 condition_id = "compare_variable"
 target_node = NodePath("System")
@@ -400,28 +444,31 @@ inputs = {
 }
 block_type = "condition"
 
-[sub_resource type="Resource" id="Resource_4rioj"]
+[sub_resource type="Resource" id="Resource_crlsd"]
 script = ExtResource("3_j21vh")
 is_branch = true
 branch_type = "if"
-branch_condition = SubResource("Resource_2q5cv")
-branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_vvbgy"), SubResource("Resource_x3kut")])
+branch_condition = SubResource("Resource_cpo3s")
+branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_2q5cv"), SubResource("Resource_4rioj")])
 block_type = "action"
+personal_id = 38
 
-[sub_resource type="Resource" id="Resource_cpo3s"]
+[sub_resource type="Resource" id="Resource_ulr6u"]
 script = ExtResource("3_j21vh")
 action_id = "play"
 target_node = NodePath("INcorrectVoiceClip")
 block_type = "action"
+personal_id = 42
 
-[sub_resource type="Resource" id="Resource_crlsd"]
+[sub_resource type="Resource" id="Resource_iud1s"]
 script = ExtResource("3_j21vh")
 is_branch = true
 branch_type = "else"
-branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_cpo3s")])
+branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_ulr6u")])
 block_type = "action"
+personal_id = 41
 
-[sub_resource type="Resource" id="Resource_ulr6u"]
+[sub_resource type="Resource" id="Resource_wccxq"]
 script = ExtResource("3_j21vh")
 action_id = "Print Message"
 target_node = NodePath(".")
@@ -430,16 +477,18 @@ inputs = {
 "message": "\"Current correct answer: \" + system.get_var(\"currentCorrectAnswer\")"
 }
 block_type = "action"
+personal_id = 43
 
-[sub_resource type="Resource" id="Resource_iud1s"]
+[sub_resource type="Resource" id="Resource_77cye"]
 script = ExtResource("2_uoxok")
-block_id = "event_1778579460_1803438691"
+block_id = "event_1784483657_3674755498"
 event_id = "On Button Pressed"
 target_node = NodePath("HoldsAnswers/FirstAnswerButton")
-actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_e3r8u"), SubResource("Resource_4rioj"), SubResource("Resource_crlsd"), SubResource("Resource_ulr6u")])
+actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_x3kut"), SubResource("Resource_crlsd"), SubResource("Resource_iud1s"), SubResource("Resource_wccxq")])
 block_type = "event"
+personal_id = 36
 
-[sub_resource type="Resource" id="Resource_wccxq"]
+[sub_resource type="Resource" id="Resource_e0h2c"]
 script = ExtResource("3_j21vh")
 action_id = "Print Message"
 target_node = NodePath(".")
@@ -448,8 +497,9 @@ inputs = {
 "message": "\"Response to second answer's button press\""
 }
 block_type = "action"
+personal_id = 45
 
-[sub_resource type="Resource" id="Resource_77cye"]
+[sub_resource type="Resource" id="Resource_fql5c"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -458,8 +508,9 @@ inputs = {
 "Value": "system.get_var(\"secondAnswerText\")"
 }
 block_type = "action"
+personal_id = 46
 
-[sub_resource type="Resource" id="Resource_e0h2c"]
+[sub_resource type="Resource" id="Resource_jvbn4"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -468,14 +519,16 @@ inputs = {
 "Value": "system.get_var(\"correctAnswerCount\") + 1"
 }
 block_type = "action"
+personal_id = 48
 
-[sub_resource type="Resource" id="Resource_fql5c"]
+[sub_resource type="Resource" id="Resource_2i8k8"]
 script = ExtResource("3_j21vh")
 action_id = "play"
 target_node = NodePath("CorrectVoiceClip")
 block_type = "action"
+personal_id = 49
 
-[sub_resource type="Resource" id="Resource_jvbn4"]
+[sub_resource type="Resource" id="Resource_jj233"]
 script = ExtResource("4_s7nm7")
 condition_id = "compare_variable"
 target_node = NodePath("System")
@@ -486,36 +539,40 @@ inputs = {
 }
 block_type = "condition"
 
-[sub_resource type="Resource" id="Resource_2i8k8"]
+[sub_resource type="Resource" id="Resource_0gvro"]
 script = ExtResource("3_j21vh")
 is_branch = true
 branch_type = "if"
-branch_condition = SubResource("Resource_jvbn4")
-branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_e0h2c"), SubResource("Resource_fql5c")])
+branch_condition = SubResource("Resource_jj233")
+branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_jvbn4"), SubResource("Resource_2i8k8")])
 block_type = "action"
+personal_id = 47
 
-[sub_resource type="Resource" id="Resource_jj233"]
+[sub_resource type="Resource" id="Resource_v6ggk"]
 script = ExtResource("3_j21vh")
 action_id = "play"
 target_node = NodePath("INcorrectVoiceClip")
 block_type = "action"
+personal_id = 51
 
-[sub_resource type="Resource" id="Resource_0gvro"]
+[sub_resource type="Resource" id="Resource_2ae07"]
 script = ExtResource("3_j21vh")
 is_branch = true
 branch_type = "else"
-branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_jj233")])
+branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_v6ggk")])
 block_type = "action"
+personal_id = 50
 
-[sub_resource type="Resource" id="Resource_v6ggk"]
+[sub_resource type="Resource" id="Resource_en1qb"]
 script = ExtResource("2_uoxok")
-block_id = "event_1778579460_678760649"
+block_id = "event_1784483657_3954116074"
 event_id = "On Button Pressed"
 target_node = NodePath("HoldsAnswers/SecondAnswerButton")
-actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_wccxq"), SubResource("Resource_77cye"), SubResource("Resource_2i8k8"), SubResource("Resource_0gvro")])
+actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_e0h2c"), SubResource("Resource_fql5c"), SubResource("Resource_0gvro"), SubResource("Resource_2ae07")])
 block_type = "event"
+personal_id = 44
 
-[sub_resource type="Resource" id="Resource_2ae07"]
+[sub_resource type="Resource" id="Resource_4a7op"]
 script = ExtResource("3_j21vh")
 action_id = "Print Message"
 target_node = NodePath(".")
@@ -524,8 +581,9 @@ inputs = {
 "message": "\"Response to third answer's button press\""
 }
 block_type = "action"
+personal_id = 53
 
-[sub_resource type="Resource" id="Resource_en1qb"]
+[sub_resource type="Resource" id="Resource_jvhj0"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -534,8 +592,9 @@ inputs = {
 "Value": "system.get_var(\"thirdAnswerText\")"
 }
 block_type = "action"
+personal_id = 54
 
-[sub_resource type="Resource" id="Resource_4a7op"]
+[sub_resource type="Resource" id="Resource_18u5c"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -544,14 +603,16 @@ inputs = {
 "Value": "system.get_var(\"correctAnswerCount\") + 1"
 }
 block_type = "action"
+personal_id = 56
 
-[sub_resource type="Resource" id="Resource_jvhj0"]
+[sub_resource type="Resource" id="Resource_a5vmf"]
 script = ExtResource("3_j21vh")
 action_id = "play"
 target_node = NodePath("CorrectVoiceClip")
 block_type = "action"
+personal_id = 57
 
-[sub_resource type="Resource" id="Resource_18u5c"]
+[sub_resource type="Resource" id="Resource_lp0wt"]
 script = ExtResource("4_s7nm7")
 condition_id = "compare_variable"
 target_node = NodePath("System")
@@ -562,36 +623,40 @@ inputs = {
 }
 block_type = "condition"
 
-[sub_resource type="Resource" id="Resource_a5vmf"]
+[sub_resource type="Resource" id="Resource_gekfw"]
 script = ExtResource("3_j21vh")
 is_branch = true
 branch_type = "if"
-branch_condition = SubResource("Resource_18u5c")
-branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_4a7op"), SubResource("Resource_jvhj0")])
+branch_condition = SubResource("Resource_lp0wt")
+branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_18u5c"), SubResource("Resource_a5vmf")])
 block_type = "action"
+personal_id = 55
 
-[sub_resource type="Resource" id="Resource_lp0wt"]
+[sub_resource type="Resource" id="Resource_a6awu"]
 script = ExtResource("3_j21vh")
 action_id = "play"
 target_node = NodePath("INcorrectVoiceClip")
 block_type = "action"
+personal_id = 59
 
-[sub_resource type="Resource" id="Resource_gekfw"]
+[sub_resource type="Resource" id="Resource_m718d"]
 script = ExtResource("3_j21vh")
 is_branch = true
 branch_type = "else"
-branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_lp0wt")])
+branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_a6awu")])
 block_type = "action"
+personal_id = 58
 
-[sub_resource type="Resource" id="Resource_a6awu"]
+[sub_resource type="Resource" id="Resource_l7q4j"]
 script = ExtResource("2_uoxok")
-block_id = "event_1778579460_1030739966"
+block_id = "event_1784483657_280021773"
 event_id = "On Button Pressed"
 target_node = NodePath("HoldsAnswers/ThirdAnswerButton")
-actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_2ae07"), SubResource("Resource_en1qb"), SubResource("Resource_a5vmf"), SubResource("Resource_gekfw")])
+actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_4a7op"), SubResource("Resource_jvhj0"), SubResource("Resource_gekfw"), SubResource("Resource_m718d")])
 block_type = "event"
+personal_id = 52
 
-[sub_resource type="Resource" id="Resource_m718d"]
+[sub_resource type="Resource" id="Resource_v4uwj"]
 script = ExtResource("3_j21vh")
 action_id = "Print Message"
 target_node = NodePath(".")
@@ -600,8 +665,9 @@ inputs = {
 "message": "\"Response to fourth answer's button press\""
 }
 block_type = "action"
+personal_id = 61
 
-[sub_resource type="Resource" id="Resource_l7q4j"]
+[sub_resource type="Resource" id="Resource_qjnoe"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -610,8 +676,9 @@ inputs = {
 "Value": "system.get_var(\"fourthAnswerText\")"
 }
 block_type = "action"
+personal_id = 62
 
-[sub_resource type="Resource" id="Resource_v4uwj"]
+[sub_resource type="Resource" id="Resource_uvq0u"]
 script = ExtResource("3_j21vh")
 action_id = "set_variable"
 target_node = NodePath("System")
@@ -620,14 +687,16 @@ inputs = {
 "Value": "system.get_var(\"correctAnswerCount\") + 1"
 }
 block_type = "action"
+personal_id = 64
 
-[sub_resource type="Resource" id="Resource_qjnoe"]
+[sub_resource type="Resource" id="Resource_ht44d"]
 script = ExtResource("3_j21vh")
 action_id = "play"
 target_node = NodePath("CorrectVoiceClip")
 block_type = "action"
+personal_id = 65
 
-[sub_resource type="Resource" id="Resource_uvq0u"]
+[sub_resource type="Resource" id="Resource_bieu4"]
 script = ExtResource("4_s7nm7")
 condition_id = "compare_variable"
 target_node = NodePath("System")
@@ -638,36 +707,40 @@ inputs = {
 }
 block_type = "condition"
 
-[sub_resource type="Resource" id="Resource_ht44d"]
+[sub_resource type="Resource" id="Resource_po1c6"]
 script = ExtResource("3_j21vh")
 is_branch = true
 branch_type = "if"
-branch_condition = SubResource("Resource_uvq0u")
-branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_v4uwj"), SubResource("Resource_qjnoe")])
+branch_condition = SubResource("Resource_bieu4")
+branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_uvq0u"), SubResource("Resource_ht44d")])
 block_type = "action"
+personal_id = 63
 
-[sub_resource type="Resource" id="Resource_bieu4"]
+[sub_resource type="Resource" id="Resource_6m3qi"]
 script = ExtResource("3_j21vh")
 action_id = "play"
 target_node = NodePath("INcorrectVoiceClip")
 block_type = "action"
+personal_id = 67
 
-[sub_resource type="Resource" id="Resource_po1c6"]
+[sub_resource type="Resource" id="Resource_pcxsw"]
 script = ExtResource("3_j21vh")
 is_branch = true
 branch_type = "else"
-branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_bieu4")])
+branch_actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_6m3qi")])
 block_type = "action"
+personal_id = 66
 
-[sub_resource type="Resource" id="Resource_6m3qi"]
+[sub_resource type="Resource" id="Resource_4gecw"]
 script = ExtResource("2_uoxok")
-block_id = "event_1778579460_4039687986"
+block_id = "event_1784483657_752477147"
 event_id = "On Button Pressed"
 target_node = NodePath("HoldsAnswers/FourthAnswerButton")
-actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_m718d"), SubResource("Resource_l7q4j"), SubResource("Resource_ht44d"), SubResource("Resource_po1c6")])
+actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_v4uwj"), SubResource("Resource_qjnoe"), SubResource("Resource_po1c6"), SubResource("Resource_pcxsw")])
 block_type = "event"
+personal_id = 60
 
-[sub_resource type="Resource" id="Resource_pcxsw"]
+[sub_resource type="Resource" id="Resource_7afg8"]
 script = ExtResource("3_j21vh")
 action_id = "Print Message"
 target_node = NodePath(".")
@@ -676,19 +749,21 @@ inputs = {
 "message": "\"First answer button's text changed\""
 }
 block_type = "action"
+personal_id = 69
 
-[sub_resource type="Resource" id="Resource_4gecw"]
+[sub_resource type="Resource" id="Resource_llv2g"]
 script = ExtResource("2_uoxok")
-block_id = "event_1778579460_3220777364"
+block_id = "event_1784483657_2359781647"
 event_id = "On Text Changed"
 target_node = NodePath("HoldsAnswers/FirstAnswerButton")
-actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_pcxsw")])
+actions = Array[ExtResource("3_j21vh")]([SubResource("Resource_7afg8")])
 block_type = "event"
+personal_id = 68
 
 [resource]
 script = ExtResource("6_rpy5k")
-events = Array[ExtResource("2_uoxok")]([SubResource("Resource_3pq7a"), SubResource("Resource_iud1s"), SubResource("Resource_v6ggk"), SubResource("Resource_a6awu"), SubResource("Resource_6m3qi"), SubResource("Resource_4gecw")])
-comments = Array[ExtResource("1_e8buc")]([SubResource("Resource_df7pu")])
+events = Array[ExtResource("2_uoxok")]([SubResource("Resource_vvbgy"), SubResource("Resource_77cye"), SubResource("Resource_en1qb"), SubResource("Resource_l7q4j"), SubResource("Resource_4gecw"), SubResource("Resource_llv2g")])
+comments = Array[ExtResource("1_e8buc")]([SubResource("Resource_j21vh")])
 item_order = Array[Dictionary]([{
 "index": 0,
 "type": "comment"
@@ -711,3 +786,4 @@ item_order = Array[Dictionary]([{
 "index": 5,
 "type": "event"
 }])
+_id_assigner = SubResource("Resource_uoxok")


### PR DESCRIPTION
# Summary
This PR introduces stable personal_id fields for all FKUnits, assigned by their parent FKEventSheet. This gives the former easier to track, reference, and work with across loads, edits, and future features. Along the way, I cleaned up several architectural areas to make FKUnit handling more consistent and future‑proof.

# Main Benefits

## Save-System-Friendliness
Stable IDs make it much easier for save/load systems to handle post-load logic. Stuff like playing the right bgm and showing the right portraits on screen. Without IDs, save files would need to store structural paths or indices, which are brittle and inflate file size. With IDs, we avoid that extra complexity.

## Version-Control-Friendliness 
Diffs become much clearer. IDs let us tell whether a specific FKUnit was:

- added
- removed
- moved
- modified

We'd otherwise need to rely on array positions (those can change a lot).

## Supports Future Features 
If we ever decide to support stuff like analytics or having an EventSheet reference stuff in another EventSheet, it'll be made much easier thanks to the stable Ids.

# Bugs Fixed
- The sheet state tracker recording snapshots while loading a sheet other than the first one opened in the same editor section

# Architectural Improvements

## on_loaded_from_disk methods for FKEventSheet and FKUnit

This makes it easier for both classes to do things like:
  - Normalize or upgrade legacy serialized data
  - Self-repair
  - Re-establish metadata
  
Thanks to that, we can change formats without too much issue.
  
## Child-Handling and _to_string overrides for FKUnits 
Now, the base class here exposes the following:
- get_children method
  - Unified child access for clients
- may_have_children method 
  - avoids unnecessary empty array allocations

Subclasses override those as needed. The _to_string overrides are for easier debugging.

## More Cohesive Serialization and Deserialization
Reduces boilerplate more than anything.

## get_real_class method
Since oftentimes, even with get_class overridden, it just returns "Resource". With our own custom method, we can make sure we're getting the specific FKUnit subtypes when logging and stuff.