### PR TITLE
FKRegistry modularization, provider loader/executor split, and related bug fixes

### DIFF
--- a/addons/flowkit/actions/Node/print_message.gd
+++ b/addons/flowkit/actions/Node/print_message.gd
@@ -18,13 +18,13 @@ func get_inputs() -> Array[FKActionInput]:
 
 static var _color_input: FKStringActionInput:
 	get:
-		return FKStringActionInput.new("Color",
+		return FKStringActionInput.new("color",
 		"Decides what BBCode color the message is wrapped in. Default: white.",
 		"white")
 
 static var _message_input: FKStringActionInput:
 	get:
-		return FKStringActionInput.new("Message", 
+		return FKStringActionInput.new("message", 
 		"The message to print. BBCode tags are supported.")
 
 func execute(_node: Node, inputs: Dictionary, _int: int = -1) -> void:

--- a/addons/flowkit/editor/Ui/fkUnits/branch_unit_ui.gd
+++ b/addons/flowkit/editor/Ui/fkUnits/branch_unit_ui.gd
@@ -89,8 +89,7 @@ func _show_context_menu() -> void:
 	context_menu.clear()
 
 	var provider = _get_branch_provider()
-	var input_type = provider.get_input_type() if provider and provider.has_method("get_input_type") \
-	else "condition"
+	var input_type = provider.get_input_type()
 
 	if _action.branch_type != "else":
 		if input_type == "condition":
@@ -159,11 +158,10 @@ func _show_add_action_context_menu() -> void:
 	add_action_context_menu.add_item("Add Action", 0)
 	add_action_context_menu.add_separator()
 
-	var branches: Array = registry.branch_providers if registry else []
+	var branches: Array[FKBranch] = registry.branch_providers if registry else []
 	for i in range(branches.size()):
 		var provider = branches[i]
-		if provider.has_method("get_name"):
-			add_action_context_menu.add_item("Add %s" % provider.get_name(), 100 + i)
+		add_action_context_menu.add_item("Add %s" % provider.get_display_name(), 100 + i)
 
 	add_action_context_menu.position = DisplayServer.mouse_get_position()
 	add_action_context_menu.popup()
@@ -172,10 +170,11 @@ func _on_add_action_context_menu_id_pressed(id: int) -> void:
 	if id == 0:
 		add_branch_action_requested.emit(self)
 	elif id >= 100:
-		var branches: Array = registry.branch_providers if registry else []
+		var branches: Array[FKBranch] = registry.branch_providers if registry else []
 		var idx := id - 100
 		if idx < branches.size():
-			add_nested_branch_requested.emit(self, branches[idx].get_id())
+			var current_branch := branches[idx];
+			add_nested_branch_requested.emit(self, current_branch.get_provider_id())
 
 func _on_add_action_hover(is_hovering: bool) -> void:
 	var color_to_use = Color(0.6, 0.65, 0.62, 1) if is_hovering \
@@ -199,7 +198,7 @@ func _update_header() -> void:
 
 func _update_type_label() -> void:
 	var provider = _get_branch_provider()
-	var name: String = provider.get_name().to_upper() if provider and provider.has_method("get_name") else "IF"
+	var name: String = provider.get_display_name().to_upper() if provider != null else "IF"
 
 	match _action.branch_type:
 		"if": type_label.text = name
@@ -234,10 +233,9 @@ func _update_condition_desc() -> void:
 		var display_name := cond.condition_id
 
 		if registry:
-			for p in registry.condition_providers:
-				if p.has_method("get_id") and p.get_id() == cond.condition_id:
-					if p.has_method("get_name"):
-						display_name = p.get_name()
+			for prov in registry.condition_providers:
+				if prov.get_provider_id() == cond.condition_id:
+					display_name = prov.get_display_name()
 					break
 
 		var neg := "NOT " if cond.negated else ""
@@ -260,15 +258,16 @@ func _update_condition_desc() -> void:
 	else:
 		condition_label.text = "(no inputs set)"
 
-func _get_branch_provider():
+func _get_branch_provider() -> FKBranch:
 	if not _action or not registry:
 		return null
 
 	var bid := _action.branch_id
 	if bid.is_empty() and _action.branch_type in ["if", "elseif", "else"]:
-		bid = "if_branch"
+		bid = "if_branch";
 
-	return registry.get_branch_provider(bid)
+	var result := registry.get_branch_provider(bid)
+	return result;
 
 # ---------------------------------------------------------
 # Branch Actions Rendering
@@ -383,9 +382,9 @@ func _get_drag_data(at_position: Vector2) -> FKDragData:
 
 func _create_drag_preview() -> Control:
 	var lbl := Label.new()
-	var provider = _get_branch_provider()
-	var name: String = provider.get_name() if provider and provider.has_method("get_name") else \
-	"Branch"
+	var provider := _get_branch_provider()
+	var name: String = provider.get_provider_name() if provider != null \
+	else "Branch"
 	lbl.text = "%s Branch" % name
 
 	var color: Color = provider.get_color() if provider and provider.has_method("get_color") else \

--- a/addons/flowkit/editor/Ui/fkUnits/condition_ui.gd
+++ b/addons/flowkit/editor/Ui/fkUnits/condition_ui.gd
@@ -10,7 +10,7 @@ signal edit_condition_requested(condition_node)
 signal selected(block_node)
 
 var condition_data: FKConditionUnit
-var registry: Node
+var registry: FKRegistry
 var is_selected: bool = false
 
 @export_category("Controls")
@@ -93,9 +93,8 @@ func _decide_display_name() -> String:
 		
 	if registry:
 		for provider in registry.condition_providers:
-			if provider.has_method("get_id") and provider.get_id() == condition_data.condition_id:
-				if provider.has_method("get_name"):
-					display_name = provider.get_name()
+			if provider.get_provider_id() == condition_data.condition_id:
+				display_name = provider.get_display_name()
 				break
 				
 	return display_name

--- a/addons/flowkit/editor/Ui/fkUnits/event_row_ui.gd
+++ b/addons/flowkit/editor/Ui/fkUnits/event_row_ui.gd
@@ -221,25 +221,24 @@ func _show_add_action_context_menu() -> void:
 	popup.add_item("Add Action", 0)
 	popup.add_separator()
 
-	var branches: Array = []
-	if registry:
-		branches = registry.branch_providers
+	var branches: Array[FKBranch] = registry.branch_providers if registry != null \
+	else []
 
 	for i in range(branches.size()):
-		var branch_provider = branches[i]
-		if branch_provider.has_method("get_name"):
-			popup.add_item("Add %s" % branch_provider.get_name(), 100 + i)
+		var branch_provider = branches[i];
+		popup.add_item("Add %s" % branch_provider.get_display_name(), 100 + i)
 
 	popup.id_pressed.connect(func(id):
 		if id == MenuChoices.ADD_EVENT_BELOW:
-			add_action_requested.emit(self)
+			add_action_requested.emit(self);
 		elif id >= 100:
-			var branch_idx = id - 100
+			var branch_idx = id - 100;
 			if branch_idx < branches.size():
-				var bid = branches[branch_idx].get_id()
+				var current_branch := branches[branch_idx];
+				var bid = current_branch.get_provider_id();
 				add_branch_requested.emit(self, bid)
-		popup.queue_free()
-	)
+		popup.queue_free();
+	);
 
 	add_child(popup)
 	popup.position = DisplayServer.mouse_get_position()
@@ -355,9 +354,8 @@ func _provider_name_from_registry(e: FKEventUnit) -> String:
 	var result: String = ""
 	if registry:
 		for provider in registry.event_providers:
-			if provider.has_method("get_id") and provider.get_id() == e.event_id:
-				if provider.has_method("get_name"):
-					result = provider.get_name()
+			if provider.get_provider_id() == e.event_id:
+				result = provider.get_display_name()
 				break
 	return result
 

--- a/addons/flowkit/editor/Ui/fkUnits/event_ui.gd
+++ b/addons/flowkit/editor/Ui/fkUnits/event_ui.gd
@@ -66,9 +66,8 @@ func _resolve_display_name(e: FKEventUnit) -> String:
 
 	if registry:
 		for provider in registry.event_providers:
-			if provider.has_method("get_id") and provider.get_id() == e.event_id:
-				if provider.has_method("get_name"):
-					name = provider.get_name()
+			if provider.get_provider_id() == e.event_id:
+				name = provider.get_display_name()
 				break
 
 	return name

--- a/addons/flowkit/editor/Ui/main_editor.gd
+++ b/addons/flowkit/editor/Ui/main_editor.gd
@@ -1575,9 +1575,8 @@ func _on_row_edit(signal_row, bound_row: FKEventRowUi) -> void:
 	# Get event provider to check if it has inputs
 	var provider_inputs = []
 	for provider in registry.event_providers:
-		if provider.has_method("get_id") and provider.get_id() == data.event_id:
-			if provider.has_method("get_inputs"):
-				provider_inputs = provider.get_inputs()
+		if provider.get_provider_id() == data.event_id:
+			provider_inputs = provider.get_inputs()
 			break
 	
 	if provider_inputs.size() > 0:
@@ -1631,8 +1630,7 @@ func _on_branch_add_elseif(branch_item: FKBranchUnitUi, event_row: FKUnitUi) -> 
 	if input_type == "condition":
 		_start_add_workflow("elseif_condition", event_row)
 	else:
-		var branch_inputs_def = branch_provider.get_inputs() if branch_provider and \
-		branch_provider.has_method("get_inputs") \
+		var branch_inputs_def = branch_provider.get_inputs() if branch_provider \
 		else []
 		pending_block_type = "elseif_evaluation"
 		if branch_inputs_def.size() > 0:
@@ -1706,9 +1704,8 @@ func _on_branch_condition_edit(branch_item: FKBranchUnitUi, event_row: FKEventRo
 		var cond := act_data.branch_condition
 		var provider_inputs = []
 		for provider in registry.condition_providers:
-			if provider.has_method("get_id") and provider.get_id() == cond.condition_id:
-				if provider.has_method("get_inputs"):
-					provider_inputs = provider.get_inputs()
+			if provider.get_provider_id() == cond.condition_id:
+				provider_inputs = provider.get_inputs()
 				break
 
 		pending_block_type = "branch_condition_edit"
@@ -1919,8 +1916,7 @@ func _start_branch_workflow(branch_id: String, target_row) -> void:
 		_start_add_workflow("branch_condition", target_row)
 	else:
 		# Evaluation type — skip node selector, go directly to expression modal
-		var branch_inputs_def: Array = branch_provider.get_inputs() if branch_provider.has_method("get_inputs") \
-		else []
+		var branch_inputs_def: Array = branch_provider.get_inputs()
 		pending_block_type = "branch_evaluation"
 		pending_target_row = target_row
 		if branch_inputs_def.size() > 0:
@@ -2006,9 +2002,8 @@ func _on_condition_edit_requested(condition_item: FKConditionUnitUi, bound_row) 
 	# Get condition provider to check if it has inputs
 	var provider_inputs: Array = []
 	for provider in registry.condition_providers:
-		if provider.has_method("get_id") and provider.get_id() == cond_data.condition_id:
-			if provider.has_method("get_inputs"):
-				provider_inputs = provider.get_inputs()
+		if provider.get_provider_id() == cond_data.condition_id:
+			provider_inputs = provider.get_inputs()
 			break
 	
 	if provider_inputs.size() > 0:
@@ -2030,7 +2025,7 @@ func _on_action_edit_requested(action_item: FKActionUnitUi, bound_row: FKUnitUi)
 	var action_provider: FKAction = act_data.action_provider
 	if action_provider == null:
 		var prov_id := act_data.get_resolved_provider_id()
-		action_provider = registry.get_action_provider(prov_id);
+		action_provider = registry.get_action_provider(prov_id)
 
 	var provider_inputs: Array[FKActionInput] = []
 	if action_provider:

--- a/addons/flowkit/editor/Ui/modals/modal_window.gd
+++ b/addons/flowkit/editor/Ui/modals/modal_window.gd
@@ -63,3 +63,5 @@ func _exit_tree() -> void:
 func _ready() -> void:
 	pass
 	
+func _get_registry() -> FKRegistry:
+	return editor_globals.registry if editor_globals else null

--- a/addons/flowkit/editor/Ui/workspace/action_ui.gd
+++ b/addons/flowkit/editor/Ui/workspace/action_ui.gd
@@ -9,7 +9,7 @@ signal edit_action_requested(action_node)
 signal selected(block_node)
 
 var action_data: FKActionUnit
-var registry: Node
+var registry: FKRegistry
 var is_selected: bool = false
 
 @export_category("Controls")
@@ -85,9 +85,8 @@ var label_text_format: String = "%s on %s%s"
 func _try_get_provider_display_name() -> String:
 	var result: String = ""
 	for provider in registry.action_providers:
-		if provider.has_method("get_id") and provider.get_id() == action_data.action_id:
-			if provider.has_method("get_name"):
-				result = provider.get_name()
+		if provider.get_provider_id() == action_data.action_id:
+			result = provider.get_display_name()
 			break
 	return result
 

--- a/addons/flowkit/editor/inspector/flowkit_inspector_section.gd
+++ b/addons/flowkit/editor/inspector/flowkit_inspector_section.gd
@@ -19,7 +19,7 @@ var content_container: VBoxContainer = null
 var behavior_section: VBoxContainer = null
 var behavior_dropdown: OptionButton = null
 var behavior_params_container: VBoxContainer = null
-var available_behaviors: Array = []
+var available_behaviors: Array[FKBehavior] = []
 
 func _ready() -> void:
 	_build_ui()
@@ -117,9 +117,6 @@ func _populate_behaviors() -> void:
 	# Get available behaviors for this node type
 	var idx: int = 1
 	for provider in registry.behavior_providers:
-		if not provider.has_method("get_supported_types"):
-			continue
-		
 		var supported_types: Array = provider.get_supported_types()
 		var is_supported: bool = false
 		
@@ -130,8 +127,7 @@ func _populate_behaviors() -> void:
 				break
 		
 		if is_supported:
-			var behavior_name: String = provider.get_display_name() \
-			if provider.has_method("get_name") else provider.get_id()
+			var behavior_name: String = provider.get_display_name();
 			
 			if behavior_name == null || behavior_name.length() == 0:
 				behavior_name = provider.get_provider_id()
@@ -163,7 +159,7 @@ func _load_current_behavior() -> void:
 	# Find and select the behavior in dropdown
 	for i in range(available_behaviors.size()):
 		var provider = available_behaviors[i]
-		if provider.has_method("get_id") and provider.get_id() == behavior_id:
+		if provider.get_provider_id() == behavior_id:
 			behavior_dropdown.select(i + 1)  # +1 because of "None" option
 			_show_behavior_params(provider, behavior_data.get("inputs", {}))
 			return
@@ -189,17 +185,16 @@ func _on_behavior_selected(index: int) -> void:
 	if behavior_index < 0 or behavior_index >= available_behaviors.size():
 		return
 	
-	var provider = available_behaviors[behavior_index]
-	var behavior_id: String = provider.get_id() if provider.has_method("get_id") else ""
+	var provider := available_behaviors[behavior_index]
+	var behavior_id: String = provider.get_provider_id();
 	
 	# Get default inputs
 	var default_inputs: Dictionary = {}
-	if provider.has_method("get_inputs"):
-		for input_def in provider.get_inputs():
-			var input_name: String = input_def.get("name", "")
-			var default_value: Variant = input_def.get("default", "")
-			if not input_name.is_empty():
-				default_inputs[input_name] = default_value
+	for input_def in provider.get_inputs():
+		var input_name: String = input_def.get("name", "");
+		var default_value: Variant = input_def.get("default", "");
+		if not input_name.is_empty():
+			default_inputs[input_name] = default_value;
 	
 	# Save behavior to node metadata
 	var behavior_data: Dictionary = {
@@ -219,13 +214,10 @@ func _clear_behavior_params() -> void:
 	for child in behavior_params_container.get_children():
 		child.queue_free()
 
-func _show_behavior_params(provider: Variant, current_inputs: Dictionary) -> void:
+func _show_behavior_params(provider: FKProvider, current_inputs: Dictionary) -> void:
 	_clear_behavior_params()
 	
-	if not provider.has_method("get_inputs"):
-		return
-	
-	var inputs: Array = provider.get_inputs()
+	var inputs: Array = provider.get_inputs();
 	if inputs.is_empty():
 		return
 	

--- a/addons/flowkit/editor/modals/select_action_modal.gd
+++ b/addons/flowkit/editor/modals/select_action_modal.gd
@@ -4,7 +4,6 @@ class_name FKSelectActionModal
 
 var selected_node_path: String = ""
 var selected_node_class: String = ""
-var available_actions: Array[FKAction] = []
 
 @export var search_box: LineEdit
 @export var item_list: ItemList
@@ -23,7 +22,6 @@ func _enter_tree() -> void:
 		return
 		
 	_recent_items_manager = FKRecentItemsManagerUi.new()
-	_load_available_actions()
 
 func _ensure_export_fields_filled():
 	var path: String
@@ -65,38 +63,6 @@ func _toggle_subs(should_sub: bool):
 		recent_item_list.item_activated.disconnect(_on_recent_item_activated)
 		
 	_is_subbed = should_sub
-	
-func _load_available_actions() -> void:
-	"""Load all action scripts from the actions folder."""
-	available_actions.clear()
-	var actions_path: String = "res://addons/flowkit/actions";
-	_scan_directory_recursive(actions_path)
-	print("[FKSelectActionModal]: Loaded ", available_actions.size(), " actions")
-
-func _scan_directory_recursive(path: String) -> void:
-	"""Recursively scan directories for action scripts."""
-	var dir: DirAccess = DirAccess.open(path)
-	if not dir:
-		return
-	
-	dir.list_dir_begin()
-	var file_name: String = dir.get_next()
-	
-	while file_name != "":
-		var full_path: String = path + "/" + file_name
-		
-		if dir.current_is_dir() and not file_name.begins_with("."):
-			# Recursively scan subdirectory
-			_scan_directory_recursive(full_path)
-		elif file_name.ends_with(".gd") and not file_name.ends_with(".gd.uid"):
-			var action_script: Variant = load(full_path)
-			if action_script:
-				var action_instance: Variant = action_script.new()
-				available_actions.append(action_instance)
-		
-		file_name = dir.get_next()
-	
-	dir.list_dir_end()
 
 func populate_actions(node_path: String, node_class: String) -> void:
 	"""Populate the list with actions compatible with the selected node."""
@@ -110,15 +76,12 @@ func populate_actions(node_path: String, node_class: String) -> void:
 	description_label.text = ""
 	
 	# Filter actions that support this node type
-	for action in available_actions:
-		var supported_types = action.get_supported_types()
-		if _is_node_compatible(node_class, supported_types):
-			var action_name := action.get_display_name()
-			var action_id := action.get_provider_id()
-			
+	var registry := _get_registry()
+	if registry:
+		for action in registry.get_actions_for_node_class(node_class):
 			_all_items_cache.append({
-				"name": action_name,
-				"metadata": {"id": action_id, "inputs": action.get_inputs()}
+				"name": action.get_display_name(),
+				"metadata": {"id": action.get_provider_id(), "inputs": action.get_inputs()}
 			})
 			
 	_update_list()
@@ -144,26 +107,6 @@ func _update_list(filter_text: String = "") -> void:
 func _on_search_text_changed(new_text: String) -> void:
 	_update_list(new_text)
 
-func _is_node_compatible(node_class: String, supported_types: Array) -> bool:
-	"""Check if a node class is compatible with the supported types."""
-	if supported_types.is_empty():
-		return false
-	
-	# Check for exact match
-	if node_class in supported_types:
-		return true
-	
-	# Check for "Node" which should match all nodes
-	if "Node" in supported_types:
-		return true
-	
-	# Check inheritance
-	for supported_type in supported_types:
-		if ClassDB.is_parent_class(node_class, supported_type):
-			return true
-	
-	return false
-
 func _on_item_activated(index: int) -> void:
 	"""Handle action selection."""
 	if item_list.is_item_disabled(index):
@@ -175,10 +118,11 @@ func _on_item_activated(index: int) -> void:
 	
 	# Find action name for recent items
 	var action_name := "";
-	for action in available_actions:
-		if action.get_provider_id() == action_id:
-			action_name = action.get_display_name()
-			break
+	var registry := _get_registry()
+	var action: FKAction = registry.get_action_provider_for_node_class(action_id, selected_node_class) if registry else null
+	if not action:
+		return
+	action_name = action.get_display_name()
 	
 	print("[FKSelectActionModal]: Action selected: ", action_id, " for node: ", selected_node_path)
 	_recent_items_manager.add_recent_action(action_id, action_name, selected_node_class)
@@ -195,10 +139,9 @@ func _on_item_selected(index: int) -> void:
 	var action_id: String = metadata["id"];
 	
 	# Find the action and get description
-	for action in available_actions:
-		if action.get_provider_id() == action_id:
-			description_label.text = action.get_description()
-			break
+	var registry := _get_registry()
+	var action: FKAction = registry.get_action_provider_for_node_class(action_id, selected_node_class) if registry else null
+	description_label.text = action.get_description() if action else ""
 
 func _on_popup_hide() -> void:
 	if search_box:
@@ -237,10 +180,11 @@ func _on_recent_item_activated(index: int) -> void:
 	
 	# Find the action to get its inputs
 	var action_inputs: Array[FKActionInput] = [];
-	for action in available_actions:
-		if action.get_provider_id() == action_id:
-			action_inputs = action.get_inputs()
-			break
+	var registry := _get_registry()
+	var action: FKAction = registry.get_action_provider_for_node_class(action_id, selected_node_class) if registry else null
+	if not action:
+		return
+	action_inputs = action.get_inputs()
 	
 	print("[FKSelectActionModal]: Recent action selected: ", action_id, " for node: ", \
 	selected_node_path)

--- a/addons/flowkit/editor/modals/select_action_modal.gd
+++ b/addons/flowkit/editor/modals/select_action_modal.gd
@@ -113,7 +113,7 @@ func populate_actions(node_path: String, node_class: String) -> void:
 	for action in available_actions:
 		var supported_types = action.get_supported_types()
 		if _is_node_compatible(node_class, supported_types):
-			var action_name = action.get_name()
+			var action_name = action.get_display_name()
 			var action_id = action.get_id()
 			
 			_all_items_cache.append({
@@ -177,7 +177,7 @@ func _on_item_activated(index: int) -> void:
 	var action_name = ""
 	for action in available_actions:
 		if action.get_id() == action_id:
-			action_name = action.get_name()
+			action_name = action.get_display_name()
 			break
 	
 	print("[FKSelectActionModal]: Action selected: ", action_id, " for node: ", selected_node_path)

--- a/addons/flowkit/editor/modals/select_action_modal.gd
+++ b/addons/flowkit/editor/modals/select_action_modal.gd
@@ -4,7 +4,7 @@ class_name FKSelectActionModal
 
 var selected_node_path: String = ""
 var selected_node_class: String = ""
-var available_actions: Array = []
+var available_actions: Array[FKAction] = []
 
 @export var search_box: LineEdit
 @export var item_list: ItemList
@@ -69,7 +69,7 @@ func _toggle_subs(should_sub: bool):
 func _load_available_actions() -> void:
 	"""Load all action scripts from the actions folder."""
 	available_actions.clear()
-	var actions_path: String = "res://addons/flowkit/actions"
+	var actions_path: String = "res://addons/flowkit/actions";
 	_scan_directory_recursive(actions_path)
 	print("[FKSelectActionModal]: Loaded ", available_actions.size(), " actions")
 
@@ -113,8 +113,8 @@ func populate_actions(node_path: String, node_class: String) -> void:
 	for action in available_actions:
 		var supported_types = action.get_supported_types()
 		if _is_node_compatible(node_class, supported_types):
-			var action_name = action.get_display_name()
-			var action_id = action.get_id()
+			var action_name := action.get_display_name()
+			var action_id := action.get_provider_id()
 			
 			_all_items_cache.append({
 				"name": action_name,
@@ -126,12 +126,12 @@ func populate_actions(node_path: String, node_class: String) -> void:
 
 func _update_list(filter_text: String = "") -> void:
 	item_list.clear()
-	var filter_lower = filter_text.to_lower()
+	var filter_lower := filter_text.to_lower()
 	
 	for item in _all_items_cache:
 		if filter_text.is_empty() or filter_lower in item["name"].to_lower():
 			item_list.add_item(item["name"])
-			var index = item_list.item_count - 1
+			var index := item_list.item_count - 1
 			item_list.set_item_metadata(index, item["metadata"])
 	
 	if item_list.item_count == 0:
@@ -170,13 +170,13 @@ func _on_item_activated(index: int) -> void:
 		return
 	
 	var metadata = item_list.get_item_metadata(index)
-	var action_id = metadata["id"]
-	var inputs = metadata["inputs"]
+	var action_id: String = metadata["id"];
+	var inputs = metadata["inputs"];
 	
 	# Find action name for recent items
-	var action_name = ""
+	var action_name := "";
 	for action in available_actions:
-		if action.get_id() == action_id:
+		if action.get_provider_id() == action_id:
 			action_name = action.get_display_name()
 			break
 	
@@ -188,15 +188,15 @@ func _on_item_activated(index: int) -> void:
 func _on_item_selected(index: int) -> void:
 	"""Update description when item is selected."""
 	if item_list.is_item_disabled(index):
-		description_label.text = ""
+		description_label.text = "";
 		return
 	
 	var metadata = item_list.get_item_metadata(index)
-	var action_id = metadata["id"]
+	var action_id: String = metadata["id"];
 	
 	# Find the action and get description
 	for action in available_actions:
-		if action.get_id() == action_id:
+		if action.get_provider_id() == action_id:
 			description_label.text = action.get_description()
 			break
 
@@ -212,7 +212,7 @@ func _populate_recent_list() -> void:
 	recent_item_list.clear()
 	
 	# Filter recent actions for current node type
-	var recent_for_type = []
+	var recent_for_type = [];
 	for recent_action in _recent_items_manager.recent_actions:
 		if recent_action["node_class"] == selected_node_class:
 			recent_for_type.append(recent_action)
@@ -224,7 +224,7 @@ func _populate_recent_list() -> void:
 	
 	for recent_action in recent_for_type:
 		recent_item_list.add_item(recent_action["name"])
-		var index = recent_item_list.item_count - 1
+		var index := recent_item_list.item_count - 1;
 		recent_item_list.set_item_metadata(index, recent_action)
 
 func _on_recent_item_activated(index: int) -> void:
@@ -233,12 +233,12 @@ func _on_recent_item_activated(index: int) -> void:
 		return
 	
 	var recent_action = recent_item_list.get_item_metadata(index)
-	var action_id = recent_action["id"]
+	var action_id: String = recent_action["id"];
 	
 	# Find the action to get its inputs
-	var action_inputs: Array = []
+	var action_inputs: Array[FKActionInput] = [];
 	for action in available_actions:
-		if action.get_id() == action_id:
+		if action.get_provider_id() == action_id:
 			action_inputs = action.get_inputs()
 			break
 	

--- a/addons/flowkit/editor/modals/select_condition_modal.gd
+++ b/addons/flowkit/editor/modals/select_condition_modal.gd
@@ -121,7 +121,7 @@ func populate_conditions(node_path: String, node_class: String) -> void:
 	for condition in available_conditions:
 		var supported_types = condition.get_supported_types()
 		if _is_node_compatible(node_class, supported_types):
-			var condition_name = condition.get_name()
+			var condition_name = condition.get_display_name()
 			var condition_id = condition.get_id()
 			
 			_all_items_cache.append({
@@ -185,7 +185,7 @@ func _on_item_activated(index: int) -> void:
 	var condition_name = ""
 	for condition in available_conditions:
 		if condition.get_id() == condition_id:
-			condition_name = condition.get_name()
+			condition_name = condition.get_display_name()
 			break
 	
 	print("[FKSelectConditionModal]: Condition selected: ", condition_id, " for node: ", selected_node_path)

--- a/addons/flowkit/editor/modals/select_condition_modal.gd
+++ b/addons/flowkit/editor/modals/select_condition_modal.gd
@@ -2,32 +2,32 @@
 extends FKModalWindow
 class_name FKSelectConditionModal
 
-var selected_node_path: String = ""
-var selected_node_class: String = ""
-var available_conditions: Array = []
+var selected_node_path: String = "";
+var selected_node_class: String = "";
+var available_conditions: Array[FKCondition] = [];
 
-@export var search_box: LineEdit
-@export var item_list: ItemList
-@export var description_label: Label
-@export var recent_item_list: ItemList
-@export var desc_panel: Panel
-@export var desc_panel_style: StyleBoxFlat
+@export var search_box: LineEdit;
+@export var item_list: ItemList;
+@export var description_label: Label;
+@export var recent_item_list: ItemList;
+@export var desc_panel: Panel;
+@export var desc_panel_style: StyleBoxFlat;
 
-var _all_items_cache: Array = []
-var _recent_items_manager: Variant = null
+var _all_items_cache: Array = [];
+var _recent_items_manager: Variant = null;
 
 
 func _toggle_subs(should_sub: bool):
 	if should_sub and not _is_subbed:
-		search_box.text_changed.connect(_on_search_text_changed)
-		item_list.item_activated.connect(_on_item_activated)
-		item_list.item_selected.connect(_on_item_selected)
-		recent_item_list.item_activated.connect(_on_recent_item_activated)
+		search_box.text_changed.connect(_on_search_text_changed);
+		item_list.item_activated.connect(_on_item_activated);
+		item_list.item_selected.connect(_on_item_selected);
+		recent_item_list.item_activated.connect(_on_recent_item_activated);
 	elif _is_subbed and !should_sub:
-		search_box.text_changed.disconnect(_on_search_text_changed)
-		item_list.item_activated.disconnect(_on_item_activated)
-		item_list.item_selected.disconnect(_on_item_selected)
-		recent_item_list.item_activated.disconnect(_on_recent_item_activated)
+		search_box.text_changed.disconnect(_on_search_text_changed);
+		item_list.item_activated.disconnect(_on_item_activated);
+		item_list.item_selected.disconnect(_on_item_selected);
+		recent_item_list.item_activated.disconnect(_on_recent_item_activated);
 	else:
 		return
 		
@@ -35,55 +35,55 @@ func _toggle_subs(should_sub: bool):
 	
 
 func _enter_tree() -> void:
-	super._enter_tree()
+	super._enter_tree();
 	
 	if is_editor_preview or is_fully_legit:
 		return
 	
-	_recent_items_manager = FKRecentItemsManagerUi.new()
-	_load_available_conditions()
+	_recent_items_manager = FKRecentItemsManagerUi.new();
+	_load_available_conditions();
 
 func _ensure_export_fields_filled():
-	var path: String
+	var path: String;
 	if not search_box:
-		path = "VBoxContainer/SearchBox"
-		search_box = get_node(path)
+		path = "VBoxContainer/SearchBox";
+		search_box = get_node(path);
 	
 	if not item_list:
-		path = "VBoxContainer/HSplitContainer/MainPanel/MainVBox/ItemList"
-		item_list = get_node(path)
+		path = "VBoxContainer/HSplitContainer/MainPanel/MainVBox/ItemList";
+		item_list = get_node(path);
 		
 	if not description_label:
 		path = "VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel/" +\
-		"ScrollContainer/DescriptionLabel"
-		description_label = get_node(path)
+		"ScrollContainer/DescriptionLabel";
+		description_label = get_node(path);
 		
 	if not recent_item_list:
 		path = "VBoxContainer/HSplitContainer/RecentPanel/RecentVBox/RecentItemList"
-		recent_item_list = get_node(path)
+		recent_item_list = get_node(path);
 		
 	if not desc_panel:
 		path = "VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel"
-		desc_panel = get_node(path)
+		desc_panel = get_node(path);
 			
 func _set_desc_panel_style():
 	if not desc_panel_style:
-		desc_panel_style = StyleBoxFlat.new()
-		desc_panel_style.bg_color = Color(0.2, 0.2, 0.2, 0.8)
-	desc_panel.add_theme_stylebox_override("panel", desc_panel_style)
+		desc_panel_style = StyleBoxFlat.new();
+		desc_panel_style.bg_color = Color(0.2, 0.2, 0.2, 0.8);
+	desc_panel.add_theme_stylebox_override("panel", desc_panel_style);
 	
 
 func _load_available_conditions() -> void:
 	"""Load all condition scripts from the conditions folder."""
-	available_conditions.clear()
-	var conditions_path: String = "res://addons/flowkit/conditions"
-	_scan_directory_recursive(conditions_path)
-	print("[FKSelectConditionModal]: Loaded ", available_conditions.size(), " conditions")
+	available_conditions.clear();
+	var conditions_path: String = "res://addons/flowkit/conditions";
+	_scan_directory_recursive(conditions_path);
+	print("[FKSelectConditionModal]: Loaded ", available_conditions.size(), " conditions");
 
 
 func _scan_directory_recursive(path: String) -> void:
 	"""Recursively scan directories for condition scripts."""
-	var dir: DirAccess = DirAccess.open(path)
+	var dir: DirAccess = DirAccess.open(path);
 	if not dir:
 		return
 	
@@ -95,12 +95,12 @@ func _scan_directory_recursive(path: String) -> void:
 		
 		if dir.current_is_dir() and not file_name.begins_with("."):
 			# Recursively scan subdirectory
-			_scan_directory_recursive(full_path)
+			_scan_directory_recursive(full_path);
 		elif file_name.ends_with(".gd") and not file_name.ends_with(".gd.uid"):
-			var condition_script: Variant = load(full_path)
+			var condition_script: Variant = load(full_path);
 			if condition_script:
-				var condition_instance: Variant = condition_script.new()
-				available_conditions.append(condition_instance)
+				var condition_instance: Variant = condition_script.new();
+				available_conditions.append(condition_instance);
 		
 		file_name = dir.get_next()
 	
@@ -121,8 +121,8 @@ func populate_conditions(node_path: String, node_class: String) -> void:
 	for condition in available_conditions:
 		var supported_types = condition.get_supported_types()
 		if _is_node_compatible(node_class, supported_types):
-			var condition_name = condition.get_display_name()
-			var condition_id = condition.get_id()
+			var condition_name = condition.get_display_name();
+			var condition_id := condition.get_provider_id();
 			
 			_all_items_cache.append({
 				"name": condition_name,
@@ -196,59 +196,60 @@ func _on_item_activated(index: int) -> void:
 func _on_item_selected(index: int) -> void:
 	"""Update description when item is selected."""
 	if item_list.is_item_disabled(index):
-		description_label.text = ""
+		description_label.text = "";
 		return
 	
-	var metadata = item_list.get_item_metadata(index)
-	var condition_id = metadata["id"]
+	var metadata = item_list.get_item_metadata(index);
+	var condition_id: String = metadata["id"];
 	
 	# Find the condition and get description
 	for condition in available_conditions:
-		if condition.get_id() == condition_id:
+		if condition.get_provider_id() == condition_id:
 			description_label.text = condition.get_description()
 			break
 
 func _on_popup_hide() -> void:
-	search_box.clear()
+	search_box.clear();
 
 func _populate_recent_list() -> void:
 	"""Populate the recent conditions list."""
 	if not recent_item_list or not _recent_items_manager:
 		return
 	
-	recent_item_list.clear()
+	recent_item_list.clear();
 	
 	# Filter recent conditions for current node type
-	var recent_for_type = []
+	var recent_for_type = [];
 	for recent_condition in _recent_items_manager.recent_conditions:
 		if recent_condition["node_class"] == selected_node_class:
-			recent_for_type.append(recent_condition)
+			recent_for_type.append(recent_condition);
 	
 	if recent_for_type.is_empty():
 		recent_item_list.add_item("(No recent items)")
-		recent_item_list.set_item_disabled(0, true)
+		recent_item_list.set_item_disabled(0, true);
 		return
 	
 	for recent_condition in recent_for_type:
 		recent_item_list.add_item(recent_condition["name"])
-		var index = recent_item_list.item_count - 1
-		recent_item_list.set_item_metadata(index, recent_condition)
+		var index = recent_item_list.item_count - 1;
+		recent_item_list.set_item_metadata(index, recent_condition);
 
 func _on_recent_item_activated(index: int) -> void:
 	"""Handle selection from recent items."""
 	if recent_item_list.is_item_disabled(index):
 		return
 	
-	var recent_condition = recent_item_list.get_item_metadata(index)
-	var condition_id = recent_condition["id"]
+	var recent_condition = recent_item_list.get_item_metadata(index);
+	var condition_id = recent_condition["id"];
 	
 	# Find the condition to get its inputs
-	var condition_inputs: Array = []
+	var condition_inputs: Array = [];
 	for condition in available_conditions:
-		if condition.get_id() == condition_id:
-			condition_inputs = condition.get_inputs()
+		if condition.get_provider_id() == condition_id:
+			condition_inputs = condition.get_inputs();
 			break
 	
-	print("[FKSelectConditionModal]: Recent condition selected: ", condition_id, " for node: ", selected_node_path)
-	_modal_signals.condition_selected.emit(selected_node_path, condition_id, condition_inputs)
-	hide()
+	print("[FKSelectConditionModal]: Recent condition selected: ", condition_id,
+	" for node: ", selected_node_path);
+	_modal_signals.condition_selected.emit(selected_node_path, condition_id, condition_inputs);
+	hide();

--- a/addons/flowkit/editor/modals/select_condition_modal.gd
+++ b/addons/flowkit/editor/modals/select_condition_modal.gd
@@ -4,7 +4,6 @@ class_name FKSelectConditionModal
 
 var selected_node_path: String = "";
 var selected_node_class: String = "";
-var available_conditions: Array[FKCondition] = [];
 
 @export var search_box: LineEdit;
 @export var item_list: ItemList;
@@ -41,7 +40,6 @@ func _enter_tree() -> void:
 		return
 	
 	_recent_items_manager = FKRecentItemsManagerUi.new();
-	_load_available_conditions();
 
 func _ensure_export_fields_filled():
 	var path: String;
@@ -72,40 +70,6 @@ func _set_desc_panel_style():
 		desc_panel_style.bg_color = Color(0.2, 0.2, 0.2, 0.8);
 	desc_panel.add_theme_stylebox_override("panel", desc_panel_style);
 	
-
-func _load_available_conditions() -> void:
-	"""Load all condition scripts from the conditions folder."""
-	available_conditions.clear();
-	var conditions_path: String = "res://addons/flowkit/conditions";
-	_scan_directory_recursive(conditions_path);
-	print("[FKSelectConditionModal]: Loaded ", available_conditions.size(), " conditions");
-
-
-func _scan_directory_recursive(path: String) -> void:
-	"""Recursively scan directories for condition scripts."""
-	var dir: DirAccess = DirAccess.open(path);
-	if not dir:
-		return
-	
-	dir.list_dir_begin()
-	var file_name: String = dir.get_next()
-	
-	while file_name != "":
-		var full_path: String = path + "/" + file_name
-		
-		if dir.current_is_dir() and not file_name.begins_with("."):
-			# Recursively scan subdirectory
-			_scan_directory_recursive(full_path);
-		elif file_name.ends_with(".gd") and not file_name.ends_with(".gd.uid"):
-			var condition_script: Variant = load(full_path);
-			if condition_script:
-				var condition_instance: Variant = condition_script.new();
-				available_conditions.append(condition_instance);
-		
-		file_name = dir.get_next()
-	
-	dir.list_dir_end()
-
 func populate_conditions(node_path: String, node_class: String) -> void:
 	"""Populate the list with conditions compatible with the selected node."""
 	selected_node_path = node_path
@@ -118,15 +82,12 @@ func populate_conditions(node_path: String, node_class: String) -> void:
 	description_label.text = ""
 	
 	# Filter conditions that support this node type
-	for condition in available_conditions:
-		var supported_types = condition.get_supported_types()
-		if _is_node_compatible(node_class, supported_types):
-			var condition_name = condition.get_display_name();
-			var condition_id := condition.get_provider_id();
-			
+	var registry := _get_registry()
+	if registry:
+		for condition in registry.get_conditions_for_node_class(node_class):
 			_all_items_cache.append({
-				"name": condition_name,
-				"metadata": {"id": condition_id, "inputs": condition.get_inputs()}
+				"name": condition.get_display_name(),
+				"metadata": {"id": condition.get_provider_id(), "inputs": condition.get_inputs()}
 			})
 			
 	_update_list()
@@ -152,26 +113,6 @@ func _update_list(filter_text: String = "") -> void:
 func _on_search_text_changed(new_text: String) -> void:
 	_update_list(new_text)
 
-func _is_node_compatible(node_class: String, supported_types: Array) -> bool:
-	"""Check if a node class is compatible with the supported types."""
-	if supported_types.is_empty():
-		return false
-	
-	# Check for exact match
-	if node_class in supported_types:
-		return true
-	
-	# Check for "Node" which should match all nodes
-	if "Node" in supported_types:
-		return true
-	
-	# Check inheritance
-	for supported_type in supported_types:
-		if ClassDB.is_parent_class(node_class, supported_type):
-			return true
-	
-	return false
-
 func _on_item_activated(index: int) -> void:
 	"""Handle condition selection."""
 	if item_list.is_item_disabled(index):
@@ -183,10 +124,11 @@ func _on_item_activated(index: int) -> void:
 	
 	# Find condition name for recent items
 	var condition_name = ""
-	for condition in available_conditions:
-		if condition.get_id() == condition_id:
-			condition_name = condition.get_display_name()
-			break
+	var registry := _get_registry()
+	var condition: FKCondition = registry.get_condition_provider_for_node_class(condition_id, selected_node_class) if registry else null
+	if not condition:
+		return
+	condition_name = condition.get_display_name()
 	
 	print("[FKSelectConditionModal]: Condition selected: ", condition_id, " for node: ", selected_node_path)
 	_recent_items_manager.add_recent_condition(condition_id, condition_name, selected_node_class)
@@ -203,10 +145,9 @@ func _on_item_selected(index: int) -> void:
 	var condition_id: String = metadata["id"];
 	
 	# Find the condition and get description
-	for condition in available_conditions:
-		if condition.get_provider_id() == condition_id:
-			description_label.text = condition.get_description()
-			break
+	var registry := _get_registry()
+	var condition: FKCondition = registry.get_condition_provider_for_node_class(condition_id, selected_node_class) if registry else null
+	description_label.text = condition.get_description() if condition else ""
 
 func _on_popup_hide() -> void:
 	search_box.clear();
@@ -244,10 +185,11 @@ func _on_recent_item_activated(index: int) -> void:
 	
 	# Find the condition to get its inputs
 	var condition_inputs: Array = [];
-	for condition in available_conditions:
-		if condition.get_provider_id() == condition_id:
-			condition_inputs = condition.get_inputs();
-			break
+	var registry := _get_registry()
+	var condition: FKCondition = registry.get_condition_provider_for_node_class(condition_id, selected_node_class) if registry else null
+	if not condition:
+		return
+	condition_inputs = condition.get_inputs();
 	
 	print("[FKSelectConditionModal]: Recent condition selected: ", condition_id,
 	" for node: ", selected_node_path);

--- a/addons/flowkit/editor/modals/select_event_modal.gd
+++ b/addons/flowkit/editor/modals/select_event_modal.gd
@@ -2,21 +2,21 @@
 extends FKModalWindow
 class_name FKSelectEventModal
 
-var selected_node_path: String = ""
-var selected_node_class: String = ""
-var available_events: Array = []
+var selected_node_path: String = "";
+var selected_node_class: String = "";
+var available_events: Array[FKEvent] = [];
 
 @export_category("UI")
-@export var search_box: LineEdit 
-@export var item_list: ItemList 
-@export var description_label: Label 
-@export var recent_item_list: ItemList 
-@export var desc_panel: Panel
+@export var search_box: LineEdit;
+@export var item_list: ItemList;
+@export var description_label: Label;
+@export var recent_item_list: ItemList;
+@export var desc_panel: Panel;
 
 @export_category("Styling")
-@export var desc_panel_style: StyleBoxFlat
+@export var desc_panel_style: StyleBoxFlat;
 
-var _all_items_cache: Array = []
+var _all_items_cache: Array = [];
 
 func _enter_tree() -> void:
 	super._enter_tree()
@@ -30,26 +30,26 @@ func _enter_tree() -> void:
 var _recent_items_manager: Variant = null
 
 func _ensure_export_fields_filled():
-	var path: String
+	var path: String;
 	if not search_box:
-		path = "VBoxContainer/SearchBox"
+		path = "VBoxContainer/SearchBox";
 		search_box = get_node(path)
 		
 	if not item_list:
-		path = "VBoxContainer/HSplitContainer/MainPanel/MainVBox/ItemList"
+		path = "VBoxContainer/HSplitContainer/MainPanel/MainVBox/ItemList";
 		item_list = get_node(path)
 		
 	if not description_label:
 		path = "VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel/" +\
-		"ScrollContainer/DescriptionLabel"
+		"ScrollContainer/DescriptionLabel";
 		description_label = get_node(path)
 	
 	if not recent_item_list:
-		path = "VBoxContainer/HSplitContainer/RecentPanel/RecentVBox/RecentItemList"
+		path = "VBoxContainer/HSplitContainer/RecentPanel/RecentVBox/RecentItemList";
 		recent_item_list = get_node(path)
 		
 	if not desc_panel:
-		path = "VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel"
+		path = "VBoxContainer/HSplitContainer/MainPanel/MainVBox/DescriptionPanel";
 		desc_panel = get_node(path)
 		
 func _apply_styling():
@@ -74,7 +74,7 @@ func _toggle_subs(on: bool):
 func _load_available_events() -> void:
 	"""Load all event scripts from the events folder."""
 	available_events.clear()
-	var events_path: String = FKEditorGlobals.PATH_TO_EVENTS_FOLDER
+	var events_path: String = FKEditorGlobals.PATH_TO_EVENTS_FOLDER;
 	_scan_directory_recursive(events_path)
 	print("[FKSelectEventModal]: Loaded ", available_events.size(), " events")
 
@@ -88,7 +88,7 @@ func _scan_directory_recursive(path: String) -> void:
 	var file_name: String = dir.get_next()
 	
 	while file_name != "":
-		var full_path: String = path + "/" + file_name
+		var full_path: String = path + "/" + file_name;
 		
 		if dir.current_is_dir() and not file_name.begins_with("."):
 			# Recursively scan subdirectory
@@ -105,39 +105,28 @@ func _scan_directory_recursive(path: String) -> void:
 
 func populate_events(node_path: String, node_class: String) -> void:
 	"""Populate the list with events compatible with the selected node."""
-	selected_node_path = node_path
-	selected_node_class = node_class
+	selected_node_path = node_path;
+	selected_node_class = node_class;
 	
 	if not item_list:
 		return
 	
 	_all_items_cache.clear()
-	description_label.text = ""
+	description_label.text = "";
 	
 	# Filter events that support this node type
 	for event in available_events:
 		# Check if this is the new FKEvent pattern or old FKEventProvider pattern
-		if event.has_method("get_id"):
-			# New FKEvent pattern
-			var supported_types = event.get_supported_types()
-			if _is_node_compatible(node_class, supported_types):
-				var event_name = event.get_display_name()
-				var event_id = event.get_id()
-				
-				_all_items_cache.append({
-					"name": event_name,
-					"metadata": event_id
-				})
-		elif event.has_method("get_events_for"):
-			# Old FKEventProvider pattern
-			var supported_types = event.get_supported_types()
-			if _is_node_compatible(node_class, supported_types):
-				var events_list = event.get_events_for(null)
-				for event_data in events_list:
-					_all_items_cache.append({
-						"name": event_data["name"],
-						"metadata": event_data["id"]
-					})
+		# New FKEvent pattern
+		var supported_types = event.get_supported_types()
+		if _is_node_compatible(node_class, supported_types):
+			var event_name := event.get_display_name()
+			var event_id := event.get_provider_id()
+			
+			_all_items_cache.append({
+				"name": event_name,
+				"metadata": event_id
+			})
 	
 	_update_list()
 	_populate_recent_list()
@@ -149,7 +138,7 @@ func _update_list(filter_text: String = "") -> void:
 	for item in _all_items_cache:
 		if filter_text.is_empty() or filter_lower in item["name"].to_lower():
 			item_list.add_item(item["name"])
-			var index = item_list.item_count - 1
+			var index := item_list.item_count - 1;
 			item_list.set_item_metadata(index, item["metadata"])
 	
 	if item_list.item_count == 0:
@@ -190,17 +179,16 @@ func _on_item_activated(index: int) -> void:
 	var event_id = item_list.get_item_metadata(index)
 	
 	# Find the event provider to get its inputs and name
-	var event_inputs: Array = []
-	var event_name = ""
+	var event_inputs: Array = [];
+	var event_name = "";
 	for event in available_events:
-		if event.has_method("get_id") and event.get_id() == event_id:
-			if event.has_method("get_inputs"):
-				event_inputs = event.get_inputs()
-			if event.has_method("get_display_name"):
-				event_name = event.get_display_name()
+		if event.get_id() == event_id:
+			event_inputs = event.get_inputs()
+			event_name = event.get_display_name()
 			break
 	
-	print("[FKSelectEventModal]: Event selected: ", event_id, " for node: ", selected_node_path, " with inputs: ", event_inputs)
+	print("[FKSelectEventModal]: Event selected: ", event_id, " for node: ",
+	selected_node_path, " with inputs: ", event_inputs)
 	_recent_items_manager.add_recent_event(event_id, event_name, selected_node_class)
 	_modal_signals.event_selected.emit(selected_node_path, event_id, event_inputs)
 	hide()
@@ -208,14 +196,14 @@ func _on_item_activated(index: int) -> void:
 func _on_item_selected(index: int) -> void:
 	"""Update description when item is selected."""
 	if item_list.is_item_disabled(index):
-		description_label.text = ""
+		description_label.text = "";
 		return
 	
 	var event_id = item_list.get_item_metadata(index)
 	
 	# Find the event and get description
 	for event in available_events:
-		if event.has_method("get_id") and event.get_id() == event_id:
+		if event.get_provider_id() == event_id:
 			description_label.text = event.get_description()
 			break
 
@@ -243,7 +231,7 @@ func _populate_recent_list() -> void:
 	
 	for recent_event in recent_for_type:
 		recent_item_list.add_item(recent_event["name"])
-		var index = recent_item_list.item_count - 1
+		var index = recent_item_list.item_count - 1;
 		recent_item_list.set_item_metadata(index, recent_event)
 
 func _on_recent_item_activated(index: int) -> void:
@@ -257,9 +245,8 @@ func _on_recent_item_activated(index: int) -> void:
 	# Find the event to get its inputs
 	var event_inputs: Array = []
 	for event in available_events:
-		if event.has_method("get_id") and event.get_id() == event_id:
-			if event.has_method("get_inputs"):
-				event_inputs = event.get_inputs()
+		if event.get_provider_id() == event_id:
+			event_inputs = event.get_inputs()
 			break
 	
 	print("[FKSelectEventModal]: Recent event selected: ", event_id, " for node: ", \

--- a/addons/flowkit/editor/modals/select_event_modal.gd
+++ b/addons/flowkit/editor/modals/select_event_modal.gd
@@ -4,7 +4,6 @@ class_name FKSelectEventModal
 
 var selected_node_path: String = "";
 var selected_node_class: String = "";
-var available_events: Array[FKEvent] = [];
 
 @export_category("UI")
 @export var search_box: LineEdit;
@@ -25,7 +24,6 @@ func _enter_tree() -> void:
 		return
 		
 	_recent_items_manager = FKRecentItemsManagerUi.new()
-	_load_available_events()
 
 var _recent_items_manager: Variant = null
 
@@ -70,38 +68,6 @@ func _toggle_subs(on: bool):
 		return
 		
 	_is_subbed = on
-	
-func _load_available_events() -> void:
-	"""Load all event scripts from the events folder."""
-	available_events.clear()
-	var events_path: String = FKEditorGlobals.PATH_TO_EVENTS_FOLDER;
-	_scan_directory_recursive(events_path)
-	print("[FKSelectEventModal]: Loaded ", available_events.size(), " events")
-
-func _scan_directory_recursive(path: String) -> void:
-	"""Recursively scan directories for event scripts."""
-	var dir: DirAccess = DirAccess.open(path)
-	if not dir:
-		return
-	
-	dir.list_dir_begin()
-	var file_name: String = dir.get_next()
-	
-	while file_name != "":
-		var full_path: String = path + "/" + file_name;
-		
-		if dir.current_is_dir() and not file_name.begins_with("."):
-			# Recursively scan subdirectory
-			_scan_directory_recursive(full_path)
-		elif file_name.ends_with(".gd") and not file_name.ends_with(".gd.uid"):
-			var event_script: Variant = load(full_path)
-			if event_script:
-				var event_instance: Variant = event_script.new()
-				available_events.append(event_instance)
-		
-		file_name = dir.get_next()
-	
-	dir.list_dir_end()
 
 func populate_events(node_path: String, node_class: String) -> void:
 	"""Populate the list with events compatible with the selected node."""
@@ -115,17 +81,12 @@ func populate_events(node_path: String, node_class: String) -> void:
 	description_label.text = "";
 	
 	# Filter events that support this node type
-	for event in available_events:
-		# Check if this is the new FKEvent pattern or old FKEventProvider pattern
-		# New FKEvent pattern
-		var supported_types = event.get_supported_types()
-		if _is_node_compatible(node_class, supported_types):
-			var event_name := event.get_display_name()
-			var event_id := event.get_provider_id()
-			
+	var registry := _get_registry()
+	if registry:
+		for event in registry.get_events_for_node_class(node_class):
 			_all_items_cache.append({
-				"name": event_name,
-				"metadata": event_id
+				"name": event.get_display_name(),
+				"metadata": event.get_provider_id()
 			})
 	
 	_update_list()
@@ -151,26 +112,6 @@ func _update_list(filter_text: String = "") -> void:
 func _on_search_text_changed(new_text: String) -> void:
 	_update_list(new_text)
 
-func _is_node_compatible(node_class: String, supported_types: Array) -> bool:
-	"""Check if a node class is compatible with the supported types."""
-	if supported_types.is_empty():
-		return false
-	
-	# Check for exact match
-	if node_class in supported_types:
-		return true
-	
-	# Check for "Node" which should match all nodes
-	if "Node" in supported_types:
-		return true
-	
-	# Check inheritance
-	for supported_type in supported_types:
-		if ClassDB.is_parent_class(node_class, supported_type):
-			return true
-	
-	return false
-
 func _on_item_activated(index: int) -> void:
 	"""Handle event selection."""
 	if item_list.is_item_disabled(index):
@@ -181,11 +122,12 @@ func _on_item_activated(index: int) -> void:
 	# Find the event provider to get its inputs and name
 	var event_inputs: Array = [];
 	var event_name = "";
-	for event in available_events:
-		if event.get_id() == event_id:
-			event_inputs = event.get_inputs()
-			event_name = event.get_display_name()
-			break
+	var registry := _get_registry()
+	var event: FKEvent = registry.get_event_provider(event_id) if registry else null
+	if not event:
+		return
+	event_inputs = event.get_inputs()
+	event_name = event.get_display_name()
 	
 	print("[FKSelectEventModal]: Event selected: ", event_id, " for node: ",
 	selected_node_path, " with inputs: ", event_inputs)
@@ -202,10 +144,9 @@ func _on_item_selected(index: int) -> void:
 	var event_id = item_list.get_item_metadata(index)
 	
 	# Find the event and get description
-	for event in available_events:
-		if event.get_provider_id() == event_id:
-			description_label.text = event.get_description()
-			break
+	var registry := _get_registry()
+	var event: FKEvent = registry.get_event_provider(event_id) if registry else null
+	description_label.text = event.get_description() if event else ""
 
 func _on_popup_hide() -> void:
 	if search_box:
@@ -244,10 +185,11 @@ func _on_recent_item_activated(index: int) -> void:
 	
 	# Find the event to get its inputs
 	var event_inputs: Array = []
-	for event in available_events:
-		if event.get_provider_id() == event_id:
-			event_inputs = event.get_inputs()
-			break
+	var registry := _get_registry()
+	var event: FKEvent = registry.get_event_provider(event_id) if registry else null
+	if not event:
+		return
+	event_inputs = event.get_inputs()
 	
 	print("[FKSelectEventModal]: Recent event selected: ", event_id, " for node: ", \
 	selected_node_path)

--- a/addons/flowkit/editor/modals/select_event_modal.gd
+++ b/addons/flowkit/editor/modals/select_event_modal.gd
@@ -121,7 +121,7 @@ func populate_events(node_path: String, node_class: String) -> void:
 			# New FKEvent pattern
 			var supported_types = event.get_supported_types()
 			if _is_node_compatible(node_class, supported_types):
-				var event_name = event.get_name()
+				var event_name = event.get_display_name()
 				var event_id = event.get_id()
 				
 				_all_items_cache.append({
@@ -196,8 +196,8 @@ func _on_item_activated(index: int) -> void:
 		if event.has_method("get_id") and event.get_id() == event_id:
 			if event.has_method("get_inputs"):
 				event_inputs = event.get_inputs()
-			if event.has_method("get_name"):
-				event_name = event.get_name()
+			if event.has_method("get_display_name"):
+				event_name = event.get_display_name()
 			break
 	
 	print("[FKSelectEventModal]: Event selected: ", event_id, " for node: ", selected_node_path, " with inputs: ", event_inputs)

--- a/addons/flowkit/editor/modals/select_node_modal.gd
+++ b/addons/flowkit/editor/modals/select_node_modal.gd
@@ -2,8 +2,6 @@
 extends FKModalWindow
 class_name FKSelectNodeModal
 
-var available_events: Array[FKEvent] = []
-
 @export var search_box: LineEdit  
 @export var item_list: ItemList
 @export var recent_item_list: ItemList
@@ -39,41 +37,7 @@ func _toggle_subs(should_sub: bool):
 func _ready() -> void:
 	if is_editor_preview:
 		return
-	# Load all available events to check compatibility
-	_load_available_event_scripts()
 	_populate_recent_list()
-
-func _load_available_event_scripts() -> void:
-	"""Load all event scripts from the events folder."""
-	available_events.clear()
-	var path := FKEditorGlobals.PATH_TO_EVENTS_FOLDER
-	_scan_directory_recursive(path)
-
-func _scan_directory_recursive(path: String) -> void:
-	"""Recursively scan directories for event scripts."""
-	var dir: DirAccess = DirAccess.open(path)
-	if not dir:
-		return
-	
-	dir.list_dir_begin()
-	var file_name: String = dir.get_next()
-	
-	while file_name != "":
-		var full_path: String = path + "/" + file_name
-		var is_subdir: bool = dir.current_is_dir() and not file_name.begins_with(".")
-		var is_event_script: bool = file_name.ends_with(".gd") and not file_name.ends_with(".gd.uid")
-		
-		if is_subdir:
-			_scan_directory_recursive(full_path)
-		elif is_event_script:
-			var event_script: Variant = load(full_path)
-			if event_script:
-				var event_instance: FKEvent = event_script.new();
-				available_events.append(event_instance);
-		
-		file_name = dir.get_next()
-	
-	dir.list_dir_end()
 
 func _populate_recent_list() -> void:
 	"""Populate the recent items list."""
@@ -182,32 +146,8 @@ func _on_search_text_changed(new_text: String) -> void:
 	_update_list(new_text)
 
 func _has_compatible_event(node_class: String) -> bool:
-	"""Check if any available event supports this node type."""
-	for event in available_events:
-		var supported_types = event.get_supported_types()
-		if _is_node_compatible(node_class, supported_types):
-			return true
-	return false
-
-func _is_node_compatible(node_class: String, supported_types: Array) -> bool:
-	"""Check if a node class is compatible with the supported types."""
-	if supported_types.is_empty():
-		return false
-	
-	# Check for exact match
-	if node_class in supported_types:
-		return true
-	
-	# Check for "Node" which should match all nodes
-	if "Node" in supported_types:
-		return true
-	
-	# Check inheritance
-	for supported_type in supported_types:
-		if ClassDB.is_parent_class(node_class, supported_type):
-			return true
-	
-	return false
+	var registry := _get_registry()
+	return registry != null and not registry.get_events_for_node_class(node_class).is_empty()
 
 func _on_item_activated(index: int) -> void:
 	# Don't allow selecting disabled items

--- a/addons/flowkit/editor/modals/select_node_modal.gd
+++ b/addons/flowkit/editor/modals/select_node_modal.gd
@@ -2,7 +2,7 @@
 extends FKModalWindow
 class_name FKSelectNodeModal
 
-var available_events: Array = []
+var available_events: Array[FKEvent] = []
 
 @export var search_box: LineEdit  
 @export var item_list: ItemList
@@ -68,8 +68,8 @@ func _scan_directory_recursive(path: String) -> void:
 		elif is_event_script:
 			var event_script: Variant = load(full_path)
 			if event_script:
-				var event_instance: Variant = event_script.new()
-				available_events.append(event_instance)
+				var event_instance: FKEvent = event_script.new();
+				available_events.append(event_instance);
 		
 		file_name = dir.get_next()
 	
@@ -184,10 +184,9 @@ func _on_search_text_changed(new_text: String) -> void:
 func _has_compatible_event(node_class: String) -> bool:
 	"""Check if any available event supports this node type."""
 	for event in available_events:
-		if event.has_method("get_supported_types"):
-			var supported_types = event.get_supported_types()
-			if _is_node_compatible(node_class, supported_types):
-				return true
+		var supported_types = event.get_supported_types()
+		if _is_node_compatible(node_class, supported_types):
+			return true
 	return false
 
 func _is_node_compatible(node_class: String, supported_types: Array) -> bool:

--- a/addons/flowkit/editor/sheet_state_tracker.gd
+++ b/addons/flowkit/editor/sheet_state_tracker.gd
@@ -2,6 +2,7 @@ extends RefCounted
 class_name FKSheetStateTracker
 
 const MAX_HISTORY := 50
+const DEBUG_MESSAGES := false
 var enabled: bool = false
 
 var _history: Array = [] # Past snapshots

--- a/addons/flowkit/generator.gd
+++ b/addons/flowkit/generator.gd
@@ -942,7 +942,7 @@ func _filter_scripts_by_usage(
 
 	for script in all_scripts:
 		var instance = script.new()
-		if instance.has_method("get_id"):
+		if instance.has_method("get_provider_id"):
 			providers.append(script)
 		else:
 			base_classes.append(script)

--- a/addons/flowkit/provider_loader.gd
+++ b/addons/flowkit/provider_loader.gd
@@ -1,0 +1,132 @@
+extends RefCounted
+class_name FKProviderLoader
+
+const DEFAULT_MANIFEST_PATH := "res://addons/flowkit/saved/provider_manifest.tres"
+
+var manifest_path: String = DEFAULT_MANIFEST_PATH
+var provider_paths: Dictionary[String, String] = {
+	"action": "res://addons/flowkit/actions",
+	"condition": "res://addons/flowkit/conditions",
+	"event": "res://addons/flowkit/events",
+	"behavior": "res://addons/flowkit/behaviors",
+	"branch": "res://addons/flowkit/branches",
+}
+
+func load_all() -> FKProviderLoadResult:
+	var result := FKProviderLoadResult.new()
+	if _load_from_manifest(result):
+		result.source = "manifest"
+	elif OS.has_feature("editor"):
+		for kind in provider_paths:
+			_scan_directory_recursive(provider_paths[kind], kind, result)
+		result.source = "directory"
+	else:
+		result.source = "unavailable"
+		result.errors.append("No provider manifest found and directory scanning is not available in exported builds. Generate the manifest in the editor.")
+
+	_collect_duplicate_id_diagnostics(result.action_providers, "action", result)
+	_collect_duplicate_id_diagnostics(result.condition_providers, "condition", result)
+	_collect_duplicate_id_diagnostics(result.event_providers, "event", result)
+	_collect_duplicate_id_diagnostics(result.behavior_providers, "behavior", result)
+	_collect_duplicate_id_diagnostics(result.branch_providers, "branch", result)
+	return result
+
+func _load_from_manifest(result: FKProviderLoadResult) -> bool:
+	if not ResourceLoader.exists(manifest_path):
+		return false
+
+	var manifest: Resource = load(manifest_path)
+	if not manifest:
+		return false
+
+	_load_manifest_scripts(manifest.get("action_scripts"), "action", result)
+	_load_manifest_scripts(manifest.get("condition_scripts"), "condition", result)
+	_load_manifest_scripts(manifest.get("event_scripts"), "event", result)
+	_load_manifest_scripts(manifest.get("behavior_scripts"), "behavior", result)
+	_load_manifest_scripts(manifest.get("branch_scripts"), "branch", result)
+	return result.get_total_provider_count() > 0
+
+func _load_manifest_scripts(scripts: Variant, kind: String, result: FKProviderLoadResult) -> void:
+	if scripts == null:
+		return
+	for script in scripts:
+		if script is GDScript:
+			_try_add_provider(script, kind, result)
+
+func _scan_directory_recursive(path: String, kind: String, result: FKProviderLoadResult) -> void:
+	var dir: DirAccess = DirAccess.open(path)
+	if not dir:
+		return
+
+	dir.list_dir_begin()
+	var file_name := dir.get_next()
+	while not file_name.is_empty():
+		var file_path := path.path_join(file_name)
+		if dir.current_is_dir() and not file_name.begins_with("."):
+			_scan_directory_recursive(file_path, kind, result)
+		elif file_name.ends_with(".gd") and not file_name.ends_with(".gd.uid"):
+			var script: Variant = load(file_path)
+			if script is GDScript:
+				_try_add_provider(script, kind, result)
+		file_name = dir.get_next()
+	dir.list_dir_end()
+
+func _try_add_provider(script: GDScript, kind: String, result: FKProviderLoadResult) -> void:
+	var instance: Variant = script.new()
+	if instance == null:
+		result.diagnostics.append("Skipping provider that returned null on new(): %s" % script.resource_path)
+		return
+	if not instance is FKProvider:
+		result.diagnostics.append("Skipping %s script that does not extend FKProvider: %s" % [kind, script.resource_path])
+		return
+	if instance.is_abstract_provider():
+		return
+
+	var provider := instance as FKProvider
+	if _provider_id_of(provider).is_empty():
+		result.diagnostics.append("Skipping %s provider with empty id: %s" % [kind, script.resource_path])
+		return
+
+	match kind:
+		"action":
+			if provider is FKAction:
+				result.action_providers.append(provider)
+			else:
+				_add_wrong_kind_diagnostic(kind, script, result)
+		"condition":
+			if provider is FKCondition:
+				result.condition_providers.append(provider)
+			else:
+				_add_wrong_kind_diagnostic(kind, script, result)
+		"event":
+			if provider is FKEvent:
+				result.event_providers.append(provider)
+			else:
+				_add_wrong_kind_diagnostic(kind, script, result)
+		"behavior":
+			if provider is FKBehavior:
+				result.behavior_providers.append(provider)
+			else:
+				_add_wrong_kind_diagnostic(kind, script, result)
+		"branch":
+			if provider is FKBranch:
+				result.branch_providers.append(provider)
+			else:
+				_add_wrong_kind_diagnostic(kind, script, result)
+
+func _add_wrong_kind_diagnostic(kind: String, script: GDScript, result: FKProviderLoadResult) -> void:
+	result.diagnostics.append("Skipping script with incompatible %s provider type: %s" % [kind, script.resource_path])
+
+func _provider_id_of(provider: FKProvider) -> String:
+	var provider_id := provider.get_provider_id().strip_edges()
+	return provider.get_id().strip_edges() if provider_id.is_empty() else provider_id
+
+func _collect_duplicate_id_diagnostics(providers: Array, kind: String, result: FKProviderLoadResult) -> void:
+	var sources_by_id: Dictionary[String, String] = {}
+	for provider in providers:
+		var provider_id := _provider_id_of(provider)
+		var source: String = provider.get_script().resource_path
+		if sources_by_id.has(provider_id):
+			result.diagnostics.append("Duplicate %s provider id '%s' in %s and %s" % [kind, provider_id, sources_by_id[provider_id], source])
+		else:
+			sources_by_id[provider_id] = source

--- a/addons/flowkit/provider_loader.gd.uid
+++ b/addons/flowkit/provider_loader.gd.uid
@@ -1,0 +1,1 @@
+uid://ctulsgopunffh

--- a/addons/flowkit/registry.gd
+++ b/addons/flowkit/registry.gd
@@ -4,9 +4,6 @@ class_name FKRegistry
 # Preload the expression evaluator
 const FKExpressionEvaluator = preload("res://addons/flowkit/runtime/expression_evaluator.gd")
 
-# Path to the provider manifest resource
-const MANIFEST_PATH = "res://addons/flowkit/saved/provider_manifest.tres"
-
 var action_providers: Array[FKAction] = []
 var condition_providers: Array[FKCondition] = []
 var event_providers: Array[FKEvent] = []
@@ -51,199 +48,31 @@ func _provider_matches_id(provider: FKProvider, wanted_id: String) -> bool:
 	var legacy_id := provider.get_id().strip_edges()
 	return legacy_id == wanted
 
-func _provider_source_of(provider: Variant) -> String:
-	if provider == null:
-		return "<null>"
-
-	if provider is Object and provider.has_method("get_script"):
-		var script: Variant = provider.get_script()
-		if script is Script and not script.resource_path.is_empty():
-			return script.resource_path
-
-	if provider is Script and not provider.resource_path.is_empty():
-		return provider.resource_path
-
-	return str(provider)
-
-func _warn_registry_duplicates() -> void:
-	_warn_duplicate_ids(action_providers, "action")
-	_warn_duplicate_ids(condition_providers, "condition")
-	_warn_duplicate_ids(event_providers, "event")
-	_warn_duplicate_ids(behavior_providers, "behavior")
-	_warn_duplicate_ids(branch_providers, "branch")
-
-func _warn_duplicate_ids(providers: Array, label: String) -> void:
-	var seen: Dictionary = {}
-	for p in providers:
-		var pid := _provider_id_of(p)
-		var source := _provider_source_of(p)
-		if pid.is_empty():
-			push_warning("[FKRegistry] %s provider has empty id in %s" % [label, source])
-			continue
-		if seen.has(pid):
-			push_warning("[FKRegistry] Duplicate %s provider id '%s' in %s and %s" % [label, pid, seen[pid], source])
-		else:
-			seen[pid] = source
-
 func load_all() -> void:
-	# Try to load from manifest first (required for exported builds)
-	if _load_from_manifest():
-		_warn_registry_duplicates()
-		print("[FKRegistry] Loaded providers from manifest: %d actions, %d conditions, %d events, %d behaviors, %d branches" % [
-			action_providers.size(),
-			condition_providers.size(),
-			event_providers.size(),
-			behavior_providers.size(),
-			branch_providers.size()
-		])
-		return
-	
-	# Fallback to directory scanning (editor/development only)
-	# This will not work in exported builds where DirAccess cannot enumerate files
-	if OS.has_feature("editor"):
-		_load_folder("actions", "action")
-		_load_folder("conditions", "condition")
-		_load_folder("events", "event")
-		_load_folder("behaviors", "behavior")
-		_load_folder("branches", "branch")
-		
-		_warn_registry_duplicates()
-		print("[FKRegistry]: Loaded providers from directories: %d actions, %d conditions, %d events, %d behaviors, %d branches" % [
-			action_providers.size(),
-			condition_providers.size(),
-			event_providers.size(),
-			behavior_providers.size(),
-			branch_providers.size()
-		])
-	else:
-		push_error("[FKRegistry]: No provider manifest found and directory scanning is not available in exported builds. Generate the manifest in the editor.")
+	var loader := FKProviderLoader.new()
+	var result := loader.load_all()
+	action_providers = result.action_providers
+	condition_providers = result.condition_providers
+	event_providers = result.event_providers
+	behavior_providers = result.behavior_providers
+	branch_providers = result.branch_providers
+
+	for diagnostic in result.diagnostics:
+		push_warning("[FKRegistry] %s" % diagnostic)
+	for error in result.errors:
+		push_error("[FKRegistry] %s" % error)
+	print("[FKRegistry] Loaded providers from %s: %d actions, %d conditions, %d events, %d behaviors, %d branches" % [
+		result.source,
+		action_providers.size(),
+		condition_providers.size(),
+		event_providers.size(),
+		behavior_providers.size(),
+		branch_providers.size()
+	])
 
 func load_providers() -> void:
 	# Alias for load_all() for backward compatibility
 	load_all()
-
-## Load providers from the pre-generated manifest resource.
-## Returns true if successful, false if manifest not found or invalid.
-func _load_from_manifest() -> bool:
-	if not ResourceLoader.exists(MANIFEST_PATH):
-		return false
-	
-	var manifest: Resource = load(MANIFEST_PATH)
-	if not manifest:
-		return false
-	
-	# Instantiate providers from the manifest scripts
-	# Base classes (no get_id) may be in the manifest to satisfy inheritance
-	# but should not be instantiated as providers.
-	if manifest.get("action_scripts"):
-		for script: GDScript in manifest.action_scripts:
-			_try_instantiate_provider(script, "action")
-
-	if manifest.get("condition_scripts"):
-		for script: GDScript in manifest.condition_scripts:
-			_try_instantiate_provider(script, "condition")
-
-	if manifest.get("event_scripts"):
-		for script: GDScript in manifest.event_scripts:
-			_try_instantiate_provider(script, "event")
-
-	if manifest.get("behavior_scripts"):
-		for script: GDScript in manifest.behavior_scripts:
-			_try_instantiate_provider(script, "behavior")
-
-	if manifest.get("branch_scripts"):
-		for script: GDScript in manifest.branch_scripts:
-			_try_instantiate_provider(script, "branch")
-	
-	var has_providers = action_providers.size() + condition_providers.size() + event_providers.size() + behavior_providers.size() + branch_providers.size() > 0
-	return has_providers
-
-
-## Safely instantiate a provider from a script, adding it to the passed
-## array if it has a valid provider ID. Skips base classes and scripts that fail to load.
-func _try_instantiate_provider(script: GDScript, kind: String) -> void:
-	if not script:
-		return
-
-	# can_instantiate() can be false during load-order warmup; try anyway.
-	var instance: Variant = script.new()
-	
-	if instance == null:
-		push_warning("[FlowKit Registry] Skipping provider that returned null on new(): %s" % script.resource_path)
-		return
-
-	var found_abstract_provider: bool = instance is FKProvider and \
-	instance.is_abstract_provider()
-	if found_abstract_provider:
-		return
-
-	var prov: FKProvider = null
-	match kind:
-		"action":
-			if instance is FKAction:
-				prov = instance as FKAction
-				if _provider_id_of(prov).is_empty():
-					push_warning("[FlowKit Registry] Skipping action provider with empty id: %s" % script.resource_path)
-					return
-				action_providers.append(prov)
-		"condition":
-			if instance is FKCondition:
-				prov = instance as FKCondition
-				if _provider_id_of(prov).is_empty():
-					push_warning("[FlowKit Registry] Skipping condition provider with empty id: %s" % script.resource_path)
-					return
-				condition_providers.append(prov)
-		"event":
-			if instance is FKEvent:
-				prov = instance as FKEvent
-				if _provider_id_of(prov).is_empty():
-					push_warning("[FlowKit Registry] Skipping event provider with empty id: %s" % script.resource_path)
-					return
-				event_providers.append(prov)
-		"behavior":
-			if instance is FKBehavior:
-				prov = instance as FKBehavior
-				if _provider_id_of(prov).is_empty():
-					push_warning("[FlowKit Registry] Skipping behavior provider with empty id: %s" % script.resource_path)
-					return
-				behavior_providers.append(prov)
-		"branch":
-			if instance is FKBranch:
-				prov = instance as FKBranch
-				if _provider_id_of(prov).is_empty():
-					push_warning("[FlowKit Registry] Skipping branch provider with empty id: %s" % script.resource_path)
-					return
-				branch_providers.append(prov)
-
-## Directory scanning for editor/development use only.
-## This will NOT work in exported builds.
-func _load_folder(subpath: String, kind: String) -> void:
-	var path: String = "res://addons/flowkit/" + subpath
-	_scan_directory_recursive(path, kind) 
-
-func _scan_directory_recursive(path: String, kind: String) -> void:
-	var dir: DirAccess = DirAccess.open(path)
-	if not dir:
-		return
-	
-	dir.list_dir_begin()
-	var file_name: String = dir.get_next()
-	
-	while file_name != "":
-		var file_path: String = path + "/" + file_name
-		
-		if dir.current_is_dir():
-			# Recursively scan subdirectories
-			_scan_directory_recursive(file_path, kind)
-		elif file_name.ends_with(".gd") and not file_name.ends_with(".uid"):
-			# Load the script and instantiate it
-			var script: Variant = load(file_path)
-			if script is GDScript:
-				_try_instantiate_provider(script, kind)
-		
-		file_name = dir.get_next()
-	
-	dir.list_dir_end()
 
 func poll_event(event_id: String, node: Node, inputs: Dictionary = {}, unit_id: int = -1, 
 scene_root: Node = null) -> bool:

--- a/addons/flowkit/registry.gd
+++ b/addons/flowkit/registry.gd
@@ -366,7 +366,7 @@ func _on_exec_completed():
 
 var _waiting_on_action: bool = false
 
-func get_behavior(behavior_id: String) -> Variant:
+func get_behavior(behavior_id: String) -> FKBehavior:
 	for provider in behavior_providers:
 		if _provider_matches_id(provider, behavior_id):
 			return provider
@@ -387,7 +387,7 @@ func remove_behavior(behavior_id: String, node: Node) -> void:
 
 # --- Branch providers -------------------------------------------------------
 
-func get_branch_provider(branch_id: String) -> Variant:
+func get_branch_provider(branch_id: String) -> FKBranch:
 	for provider in branch_providers:
 		if _provider_matches_id(provider, branch_id):
 			return provider

--- a/addons/flowkit/registry.gd
+++ b/addons/flowkit/registry.gd
@@ -74,6 +74,27 @@ func load_providers() -> void:
 	# Alias for load_all() for backward compatibility
 	load_all()
 
+func get_actions_for_node_class(node_class: String) -> Array[FKAction]:
+	var result: Array[FKAction] = []
+	for provider in action_providers:
+		if provider.supports_node_class(node_class):
+			result.append(provider)
+	return result
+
+func get_conditions_for_node_class(node_class: String) -> Array[FKCondition]:
+	var result: Array[FKCondition] = []
+	for provider in condition_providers:
+		if provider.supports_node_class(node_class):
+			result.append(provider)
+	return result
+
+func get_events_for_node_class(node_class: String) -> Array[FKEvent]:
+	var result: Array[FKEvent] = []
+	for provider in event_providers:
+		if provider.supports_node_class(node_class):
+			result.append(provider)
+	return result
+
 func poll_event(event_id: String, node: Node, inputs: Dictionary = {}, unit_id: int = -1, 
 scene_root: Node = null) -> bool:
 	for provider in event_providers:
@@ -176,6 +197,17 @@ func get_action_provider(action_id: String, target_node: Node = null) -> FKActio
 
 	return null
 
+func get_action_provider_for_node_class(action_id: String, node_class: String) -> FKAction:
+	for provider in action_providers:
+		if provider.get_provider_id().strip_edges() == action_id:
+			return provider
+
+	for provider in action_providers:
+		if provider.get_id().strip_edges() == action_id and provider.supports_node_class(node_class):
+			return provider
+
+	return null
+
 func get_condition_provider(condition_id: String, target_node: Node = null) -> FKCondition:
 	# Canonical IDs must be globally unique.
 	for provider in condition_providers:
@@ -187,6 +219,17 @@ func get_condition_provider(condition_id: String, target_node: Node = null) -> F
 		if provider.get_id().strip_edges() == condition_id:
 			if target_node == null or provider.supports_node(target_node):
 				return provider
+
+	return null
+
+func get_condition_provider_for_node_class(condition_id: String, node_class: String) -> FKCondition:
+	for provider in condition_providers:
+		if provider.get_provider_id().strip_edges() == condition_id:
+			return provider
+
+	for provider in condition_providers:
+		if provider.get_id().strip_edges() == condition_id and provider.supports_node_class(node_class):
+			return provider
 
 	return null
 	

--- a/addons/flowkit/registry.gd
+++ b/addons/flowkit/registry.gd
@@ -21,7 +21,7 @@ var event_alias_to_id: Dictionary[String, String] = {}
 var behavior_alias_to_id: Dictionary[String, String] = {}
 var branch_alias_to_id: Dictionary[String, String] = {}
 
-func _enter_tree() -> void:
+func _init() -> void:
 	_provider_executor = FKProviderExecutor.new(self)
 
 func _provider_id_of(provider: FKProvider) -> String:

--- a/addons/flowkit/registry.gd
+++ b/addons/flowkit/registry.gd
@@ -1,8 +1,7 @@
 extends Node
 class_name FKRegistry
 
-# Preload the expression evaluator
-const FKExpressionEvaluator = preload("res://addons/flowkit/runtime/expression_evaluator.gd")
+var _provider_executor: FKProviderExecutor
 
 var action_providers: Array[FKAction] = []
 var condition_providers: Array[FKCondition] = []
@@ -21,6 +20,9 @@ var condition_alias_to_id: Dictionary[String, String] = {}
 var event_alias_to_id: Dictionary[String, String] = {}
 var behavior_alias_to_id: Dictionary[String, String] = {}
 var branch_alias_to_id: Dictionary[String, String] = {}
+
+func _enter_tree() -> void:
+	_provider_executor = FKProviderExecutor.new(self)
 
 func _provider_id_of(provider: FKProvider) -> String:
 	var result := "";
@@ -97,14 +99,7 @@ func get_events_for_node_class(node_class: String) -> Array[FKEvent]:
 
 func poll_event(event_id: String, node: Node, inputs: Dictionary = {}, unit_id: int = -1, 
 scene_root: Node = null) -> bool:
-	for provider in event_providers:
-		if _provider_matches_id(provider, event_id):
-			if provider.has_method("poll"):
-				# Evaluate expressions in inputs before polling
-				var evaluated_inputs: Dictionary 
-				evaluated_inputs = FKExpressionEvaluator.evaluate_inputs(inputs, node, scene_root)
-				return provider.poll(node, evaluated_inputs, unit_id)
-	return false
+	return _provider_executor.poll_event(event_id, node, inputs, unit_id, scene_root)
 
 ## Returns the event provider instance for the given event_id, or null.
 func get_event_provider(event_id: String) -> Variant:
@@ -124,64 +119,23 @@ func create_event_instance(event_id: String) -> Variant:
 ## Call setup() on an event provider so it can connect to signals on the target node.
 ## trigger_callback is a Callable the provider can call to fire the unit immediately.
 func setup_event(event_id: String, node: Node, trigger_callback: Callable, unit_id: int = -1) -> void:
-	var provider: Variant = get_event_provider(event_id)
-	if provider and provider.has_method("setup"):
-		provider.setup(node, trigger_callback, unit_id)
+	_provider_executor.setup_event(event_id, node, trigger_callback, unit_id)
 
 ## Call teardown() on an event provider so it can disconnect signals / clean up.
 func teardown_event(event_id: String, node: Node, unit_id: int = -1) -> void:
-	var provider: Variant = get_event_provider(event_id)
-	if provider and provider.has_method("teardown"):
-		provider.teardown(node, unit_id)
+	_provider_executor.teardown_event(event_id, node, unit_id)
 
 ## Returns true if the event provider with the given id is a signal-based event.
 func is_signal_event(event_id: String) -> bool:
-	var provider: Variant = get_event_provider(event_id)
-	if provider and provider.has_method("is_signal_event"):
-		return provider.is_signal_event()
-	return false
+	return _provider_executor.is_signal_event(event_id)
 
 func check_condition(condition_id: String, node: Node, inputs: Dictionary, 
 negated: bool = false, scene_root: Node = null, unit_id: int = -1) -> bool:
-	for provider in condition_providers:
-		if _provider_matches_id(provider, condition_id):
-			if provider.has_method("check"):
-				# Evaluate expressions in inputs before checking
-				# Use node as context for variable resolution (not scene_root)
-				# Pass node as target_node so n_ variable lookups resolve on the correct node
-				var context = node
-				var evaluated_inputs: Dictionary = FKExpressionEvaluator.evaluate_inputs(inputs, context, scene_root, node)
-				var result = provider.check(node, evaluated_inputs, unit_id)
-				return not result if negated else result
-	return false
+	return _provider_executor.check_condition(condition_id, node, inputs, negated, scene_root, unit_id)
 
 func execute_action(action_id: String, node: Node, inputs: Dictionary, 
 scene_root: Node = null, unit_id: int = -1) -> Variant:
-	var provider := get_action_provider(action_id, node)
-	if not provider or not provider.has_method("execute"):
-		return null
-
-	# Use scene_root as the base instance so get_node() resolves from the scene root.
-	# Pass the original node as target_node so n_ variable lookups resolve on the correct node.
-	var context = scene_root if scene_root else node
-	var evaluated_inputs: Dictionary = FKExpressionEvaluator.evaluate_inputs(inputs, context, 
-	scene_root, node)
-
-	var is_multi_frame_action: bool = provider.has_method("requires_multi_frames") and \
-	provider.requires_multi_frames()
-	if is_multi_frame_action:
-		_waiting_on_action = true
-		provider.exec_completed.connect(_on_exec_completed)
-		# Need to listen for completion before execution, otherwise single-frame actions can freeze.
-
-	provider.execute(node, evaluated_inputs, unit_id)
-	while _waiting_on_action:
-		await node.get_tree().process_frame
-
-	if is_multi_frame_action:
-		provider.exec_completed.disconnect(_on_exec_completed)
-
-	return provider
+	return await _provider_executor.execute_action(action_id, node, inputs, scene_root, unit_id)
 
 func get_action_provider(action_id: String, target_node: Node = null) -> FKAction:
 	# Canonical IDs must be globally unique.
@@ -233,11 +187,6 @@ func get_condition_provider_for_node_class(condition_id: String, node_class: Str
 
 	return null
 	
-func _on_exec_completed():
-	_waiting_on_action = false
-
-var _waiting_on_action: bool = false
-
 func get_behavior(behavior_id: String) -> FKBehavior:
 	for provider in behavior_providers:
 		if _provider_matches_id(provider, behavior_id):
@@ -245,17 +194,10 @@ func get_behavior(behavior_id: String) -> FKBehavior:
 	return null
 
 func apply_behavior(behavior_id: String, node: Node, inputs: Dictionary = {}, scene_root: Node = null) -> void:
-	var behavior: Variant = get_behavior(behavior_id)
-	if behavior and behavior.has_method("apply"):
-		# Use scene_root as context if provided, otherwise use the node
-		var context = scene_root if scene_root else node
-		var evaluated_inputs: Dictionary = FKExpressionEvaluator.evaluate_inputs(inputs, context, scene_root)
-		behavior.apply(node, evaluated_inputs)
+	_provider_executor.apply_behavior(behavior_id, node, inputs, scene_root)
 
 func remove_behavior(behavior_id: String, node: Node) -> void:
-	var behavior: Variant = get_behavior(behavior_id)
-	if behavior and behavior.has_method("remove"):
-		behavior.remove(node)
+	_provider_executor.remove_behavior(behavior_id, node)
 
 # --- Branch providers -------------------------------------------------------
 
@@ -279,7 +221,4 @@ func resolve_branch_id(act_branch_id: String, act_branch_type: String) -> String
 
 ## Evaluate branch inputs through the expression evaluator.
 func evaluate_branch_inputs(inputs: Dictionary, scene_root: Node) -> Dictionary:
-	if inputs.is_empty():
-		return {}
-	var context = scene_root if scene_root else null
-	return FKExpressionEvaluator.evaluate_inputs(inputs, context, scene_root)
+	return _provider_executor.evaluate_branch_inputs(inputs, scene_root)

--- a/addons/flowkit/resources/provider_base.gd
+++ b/addons/flowkit/resources/provider_base.gd
@@ -71,19 +71,17 @@ func supports_node_class(node_class: String) -> bool:
 	if node_class.is_empty():
 		return false
 
-	var supported := get_supported_types()
+	var supported: Array = get_supported_types()
 	if supported.is_empty():
 		return false
 
-	if "Node" in supported:
-		return true
-
-	if node_class in supported:
+	if "Node" in supported or node_class in supported:
 		return true
 
 	for supported_type in supported:
-		if ClassDB.class_exists(supported_type) and ClassDB.is_parent_class(node_class, supported_type):
-			return true
+		if supported_type is String and ClassDB.class_exists(supported_type):
+			if ClassDB.is_parent_class(node_class, supported_type):
+				return true
 
 	return false
 

--- a/addons/flowkit/resources/provider_base.gd
+++ b/addons/flowkit/resources/provider_base.gd
@@ -40,7 +40,7 @@ func get_name() -> String:
 	return "Invalid" 
 
 func get_display_name() -> String:
-	return "Invalid" 
+	return get_name() # For backwards compat
 
 func get_description() -> String:
 	return "No description provided."

--- a/addons/flowkit/resources/provider_load_result.gd
+++ b/addons/flowkit/resources/provider_load_result.gd
@@ -1,0 +1,15 @@
+extends RefCounted
+class_name FKProviderLoadResult
+
+var action_providers: Array[FKAction] = []
+var condition_providers: Array[FKCondition] = []
+var event_providers: Array[FKEvent] = []
+var behavior_providers: Array[FKBehavior] = []
+var branch_providers: Array[FKBranch] = []
+var source: String = ""
+var diagnostics: Array[String] = []
+var errors: Array[String] = []
+
+func get_total_provider_count() -> int:
+	return action_providers.size() + condition_providers.size() + event_providers.size() + \
+	behavior_providers.size() + branch_providers.size()

--- a/addons/flowkit/resources/provider_load_result.gd.uid
+++ b/addons/flowkit/resources/provider_load_result.gd.uid
@@ -1,0 +1,1 @@
+uid://csfur3hjea14h

--- a/addons/flowkit/runtime/flowkit_engine.gd
+++ b/addons/flowkit/runtime/flowkit_engine.gd
@@ -1,10 +1,21 @@
 extends Node
 class_name FlowKitEngine
+const ExpressionEvaluator = preload("res://addons/flowkit/runtime/expression_evaluator.gd");
 
-const ExpressionEvaluator = preload("res://addons/flowkit/runtime/expression_evaluator.gd")
+class SheetEntry:
+	var sheet: FKEventSheet
+	var root: Node
+	var scene_name: String
+	var uid: int
+
+	func _init(p_sheet: FKEventSheet, p_root: Node, p_scene_name: String, p_uid: int) -> void:
+		sheet = p_sheet
+		root = p_root
+		scene_name = p_scene_name
+		uid = p_uid
 
 var registry: FKRegistry
-var active_sheets: Array = []  # Each entry: {"sheet": FKEventSheet, "root": Node, "scene_name": String, "uid": int}
+var active_sheets: Array[SheetEntry] = []
 var last_scene: Node = null
 var active_behavior_nodes: Array = []  # Track nodes with active behaviors
 var _event_unit_providers: Dictionary = {}  # FKUnit uid -> per-unit event provider instance
@@ -125,7 +136,7 @@ func _load_sheets_for_scene(scene_root: Node) -> void:
 			var sheet: FKEventSheet = load(sheet_path)
 			if sheet:
 				sheet.on_loaded_from_disk()
-				var entry := {"sheet": sheet, "root": node_root, "scene_name": scene_name, "uid": uid}
+				var entry := SheetEntry.new(sheet, node_root, scene_name, uid)
 				active_sheets.append(entry)
 				# Create per-unit event provider instances (each unit gets its own)
 				_create_unit_providers(entry)
@@ -159,21 +170,18 @@ func _collect_node_paths(node: Node, uid_to_node: Dictionary) -> void:
 
 ## Create a new event provider instance for each FKEventUnit in a sheet entry.
 ## This ensures each of those has its own isolated state.
-func _create_unit_providers(entry: Dictionary) -> void:
-	var sheet: FKEventSheet = entry.get("sheet", null)
-	if not sheet:
-		return
-
+func _create_unit_providers(entry: SheetEntry) -> void:
+	var sheet: FKEventSheet = entry.sheet
 	var log_message: String = ""
-	var sheet_uid: int = entry.get("uid", -1)
+	var sheet_uid: int = entry.uid
 	if sheet_uid < 0:
-		log_message = "[FlowKit] Invalid sheet UID for entry: %s" % str(entry)
+		log_message = "[FlowKit] Invalid sheet UID for scene: %s" % entry.scene_name
 		push_warning(log_message)
 		return
 
 	var all_events: Array = sheet.get_all_events()
 	
-	var sheet_label: String = str(entry.get("scene_name", "unknown_scene"))
+	var sheet_label: String = entry.scene_name
 	if sheet is Resource and not sheet.resource_path.is_empty():
 		sheet_label = sheet.resource_path.get_file()
 	for unit in all_events:
@@ -207,14 +215,9 @@ func _get_all_events(sheet: FKEventSheet) -> Array:
 	_collect_events_from_groups(sheet.groups, events)
 	return events
 
-func _run_sheet(entry: Dictionary) -> void:
-	# Entry is a dictionary with keys: "sheet" and "root"
-	var sheet: FKEventSheet = entry.get("sheet", null)
-	var root_node: Node = entry.get("root", null)
-
-	if not sheet:
-		return
-
+func _run_sheet(entry: SheetEntry) -> void:
+	var sheet: FKEventSheet = entry.sheet
+	var root_node: Node = entry.root
 	# Root node for resolving node paths in this sheet
 	var current_root: Node = root_node
 	if not current_root or not is_instance_valid(current_root):
@@ -247,7 +250,7 @@ func _run_sheet(entry: Dictionary) -> void:
 
 	# Collect all events from the sheet (both top-level and nested in groups)
 	var all_events: Array = sheet.get_all_events()
-	var sheet_uid: int = entry.get("uid", -1)
+	var sheet_uid: int = entry.uid
 
 	# Process each event unit individually
 	for unit in all_events:
@@ -298,11 +301,11 @@ func _run_sheet(entry: Dictionary) -> void:
 ## Set up signal-based events for a loaded sheet entry.
 ## For each FKEventUnit, calls provider.setup() with a trigger callback
 ## so signal events can connect to Godot signals and fire immediately.
-func _setup_signal_events(entry: Dictionary) -> void:
-	var sheet: FKEventSheet = entry.get("sheet", null)
-	var root_node: Node = entry.get("root", null)
-	var sheet_uid: int = entry.get("uid", -1)
-	if not sheet or not root_node or not is_instance_valid(root_node) or sheet_uid < 0:
+func _setup_signal_events(entry: SheetEntry) -> void:
+	var sheet: FKEventSheet = entry.sheet
+	var root_node: Node = entry.root
+	var sheet_uid: int = entry.uid
+	if not root_node or not is_instance_valid(root_node) or sheet_uid < 0:
 		return
 
 	var all_events: Array = sheet.get_all_events()
@@ -333,10 +336,10 @@ func _setup_signal_events(entry: Dictionary) -> void:
 ## Teardown all signal events across every active sheet.
 func _teardown_all_signal_events() -> void:
 	for entry in active_sheets:
-		var sheet: FKEventSheet = entry.get("sheet", null)
-		var root_node: Node = entry.get("root", null)
-		var sheet_uid: int = entry.get("uid", -1)
-		if not sheet or not root_node or not is_instance_valid(root_node) or sheet_uid < 0:
+		var sheet: FKEventSheet = entry.sheet
+		var root_node: Node = entry.root
+		var sheet_uid: int = entry.uid
+		if not root_node or not is_instance_valid(root_node) or sheet_uid < 0:
 			continue
 
 		var all_events: Array = sheet.get_all_events()
@@ -466,9 +469,11 @@ func _process_behaviors(delta: float, is_physics: bool) -> void:
 		
 		# Call the appropriate process method
 		if is_physics:
-			behavior.physics_process(node, delta, inputs)
+			if behavior.has_method("physics_process"):
+				behavior.physics_process(node, delta, inputs)
 		else:
-			behavior.process(node, delta, inputs)
+			if behavior.has_method("process"):
+				behavior.process(node, delta, inputs)
 
 func get_class() -> String:
 	return "FlowKitEngine"

--- a/addons/flowkit/runtime/flowkit_engine.gd
+++ b/addons/flowkit/runtime/flowkit_engine.gd
@@ -466,11 +466,9 @@ func _process_behaviors(delta: float, is_physics: bool) -> void:
 		
 		# Call the appropriate process method
 		if is_physics:
-			if behavior.has_method("physics_process"):
-				behavior.physics_process(node, delta, inputs)
+			behavior.physics_process(node, delta, inputs)
 		else:
-			if behavior.has_method("process"):
-				behavior.process(node, delta, inputs)
+			behavior.process(node, delta, inputs)
 
 func get_class() -> String:
 	return "FlowKitEngine"

--- a/addons/flowkit/runtime/provider_executor.gd
+++ b/addons/flowkit/runtime/provider_executor.gd
@@ -1,0 +1,87 @@
+extends RefCounted
+class_name FKProviderExecutor
+
+const FKExpressionEvaluator = preload("res://addons/flowkit/runtime/expression_evaluator.gd")
+
+var registry: FKRegistry
+var _waiting_on_action: bool = false
+
+func _init(p_registry: FKRegistry) -> void:
+	registry = p_registry
+
+func poll_event(event_id: String, node: Node, inputs: Dictionary = {}, unit_id: int = -1, \
+scene_root: Node = null) -> bool:
+	var provider: Variant = registry.get_event_provider(event_id)
+	if not provider or not provider.has_method("poll"):
+		return false
+
+	var evaluated_inputs: Dictionary = FKExpressionEvaluator.evaluate_inputs(inputs, node, scene_root)
+	return provider.poll(node, evaluated_inputs, unit_id)
+
+func setup_event(event_id: String, node: Node, trigger_callback: Callable, unit_id: int = -1) -> void:
+	var provider: Variant = registry.get_event_provider(event_id)
+	if provider and provider.has_method("setup"):
+		provider.setup(node, trigger_callback, unit_id)
+
+func teardown_event(event_id: String, node: Node, unit_id: int = -1) -> void:
+	var provider: Variant = registry.get_event_provider(event_id)
+	if provider and provider.has_method("teardown"):
+		provider.teardown(node, unit_id)
+
+func is_signal_event(event_id: String) -> bool:
+	var provider: Variant = registry.get_event_provider(event_id)
+	return provider != null and provider.has_method("is_signal_event") and provider.is_signal_event()
+
+func check_condition(condition_id: String, node: Node, inputs: Dictionary, \
+negated: bool = false, scene_root: Node = null, unit_id: int = -1) -> bool:
+	var provider := registry.get_condition_provider(condition_id, node)
+	if not provider or not provider.has_method("check"):
+		return false
+
+	var evaluated_inputs: Dictionary = FKExpressionEvaluator.evaluate_inputs(inputs, node, scene_root, node)
+	var result = provider.check(node, evaluated_inputs, unit_id)
+	return not result if negated else result
+
+func execute_action(action_id: String, node: Node, inputs: Dictionary, \
+scene_root: Node = null, unit_id: int = -1) -> Variant:
+	var provider := registry.get_action_provider(action_id, node)
+	if not provider or not provider.has_method("execute"):
+		return null
+
+	var context := scene_root if scene_root else node
+	var evaluated_inputs: Dictionary = FKExpressionEvaluator.evaluate_inputs(inputs, context, scene_root, node)
+	var is_multi_frame_action: bool = provider.has_method("requires_multi_frames") and \
+	provider.requires_multi_frames()
+	if is_multi_frame_action:
+		_waiting_on_action = true
+		provider.exec_completed.connect(_on_exec_completed)
+
+	provider.execute(node, evaluated_inputs, unit_id)
+	while _waiting_on_action:
+		await node.get_tree().process_frame
+
+	if is_multi_frame_action:
+		provider.exec_completed.disconnect(_on_exec_completed)
+
+	return provider
+
+func apply_behavior(behavior_id: String, node: Node, inputs: Dictionary = {}, scene_root: Node = null) -> void:
+	var behavior: Variant = registry.get_behavior(behavior_id)
+	if behavior and behavior.has_method("apply"):
+		var context := scene_root if scene_root else node
+		var evaluated_inputs: Dictionary = FKExpressionEvaluator.evaluate_inputs(inputs, context, scene_root)
+		behavior.apply(node, evaluated_inputs)
+
+func remove_behavior(behavior_id: String, node: Node) -> void:
+	var behavior: Variant = registry.get_behavior(behavior_id)
+	if behavior and behavior.has_method("remove"):
+		behavior.remove(node)
+
+func evaluate_branch_inputs(inputs: Dictionary, scene_root: Node) -> Dictionary:
+	if inputs.is_empty():
+		return {}
+	var context := scene_root if scene_root else null
+	return FKExpressionEvaluator.evaluate_inputs(inputs, context, scene_root)
+
+func _on_exec_completed() -> void:
+	_waiting_on_action = false

--- a/addons/flowkit/runtime/provider_executor.gd.uid
+++ b/addons/flowkit/runtime/provider_executor.gd.uid
@@ -1,0 +1,1 @@
+uid://bcvr2kxj5abpu

--- a/tests/editor/managers/test_sheet_state_tracker.gd
+++ b/tests/editor/managers/test_sheet_state_tracker.gd
@@ -1,8 +1,12 @@
 extends GutTest
 
-func test_undo_basic_behavior():
-	var state_tracker := FKSheetStateTracker.new()
+var state_tracker: FKSheetStateTracker
 
+func before_each() -> void:
+	state_tracker = FKSheetStateTracker.new()
+	state_tracker.enabled = true
+
+func test_undo_basic_behavior():
 	var firstSnapshot: Array[FKUnit] = [FKEventUnit.new()]
 	var secondSnapshot: Array[FKUnit] = [FKEventUnit.new(), FKConditionUnit.new()]
 
@@ -13,7 +17,7 @@ func test_undo_basic_behavior():
 
 	var result := state_tracker.get_previous_snapshot(secondSnapshot)
 
-	# Should return the previous snapshot (s1)
+	# Should return the most recently recorded snapshot (s2).
 	assert_eq(result.size(), secondSnapshot.size())
 	assert_true(result[0] is FKEventUnit)
 
@@ -21,8 +25,6 @@ func test_undo_basic_behavior():
 	assert_true(state_tracker.has_next())
 
 func test_undo_manager_deep_copy():
-	var state_tracker := FKSheetStateTracker.new()
-
 	var evBlock := FKEventUnit.new()
 	evBlock.inputs = {"x": 1}
 	var state: Array[FKUnit] = [evBlock]
@@ -41,10 +43,7 @@ func test_undo_manager_deep_copy():
 	var deep_copy_success := not is_same(popped[0], evBlock)
 	assert_true(deep_copy_success)
 
-
 func test_redo_restores_state():
-	var state_tracker := FKSheetStateTracker.new()
-
 	var firstSnapshot: Array[FKUnit] = [FKEventUnit.new()]
 	var secondSnapshot: Array[FKUnit] = [FKEventUnit.new(), FKActionUnit.new()]
 
@@ -60,3 +59,10 @@ func test_redo_restores_state():
 	var redo_result := state_tracker.get_next_snapshot(undo_result)
 	assert_eq(redo_result.size(), secondSnapshot.size())
 	assert_true(redo_result[1] is FKActionUnit)
+
+func test_disabled_tracker_does_not_record_history():
+	var disabled_tracker := FKSheetStateTracker.new()
+
+	disabled_tracker.record_snapshot([FKEventUnit.new()])
+
+	assert_false(disabled_tracker.has_previous())

--- a/tests/fixtures/providers/action/abstract_action.gd
+++ b/tests/fixtures/providers/action/abstract_action.gd
@@ -1,0 +1,7 @@
+extends FKAction
+
+func is_abstract_provider() -> bool:
+	return true
+
+func get_provider_id() -> String:
+	return "abstract_action"

--- a/tests/fixtures/providers/action/abstract_action.gd.uid
+++ b/tests/fixtures/providers/action/abstract_action.gd.uid
@@ -1,0 +1,1 @@
+uid://7q4d53eeaq0b

--- a/tests/fixtures/providers/action/duplicate_one.gd
+++ b/tests/fixtures/providers/action/duplicate_one.gd
@@ -1,0 +1,4 @@
+extends FKAction
+
+func get_provider_id() -> String:
+	return "duplicate_action"

--- a/tests/fixtures/providers/action/duplicate_one.gd.uid
+++ b/tests/fixtures/providers/action/duplicate_one.gd.uid
@@ -1,0 +1,1 @@
+uid://b86lg5kdrf2b1

--- a/tests/fixtures/providers/action/duplicate_two.gd
+++ b/tests/fixtures/providers/action/duplicate_two.gd
@@ -1,0 +1,4 @@
+extends FKAction
+
+func get_provider_id() -> String:
+	return "duplicate_action"

--- a/tests/fixtures/providers/action/duplicate_two.gd.uid
+++ b/tests/fixtures/providers/action/duplicate_two.gd.uid
@@ -1,0 +1,1 @@
+uid://dvvj15um7qaj0

--- a/tests/fixtures/providers/action/empty_id_action.gd
+++ b/tests/fixtures/providers/action/empty_id_action.gd
@@ -1,0 +1,4 @@
+extends FKAction
+
+func get_provider_id() -> String:
+	return " "

--- a/tests/fixtures/providers/action/empty_id_action.gd.uid
+++ b/tests/fixtures/providers/action/empty_id_action.gd.uid
@@ -1,0 +1,1 @@
+uid://b0dk67a812ofw

--- a/tests/fixtures/providers/action/not_a_provider.gd
+++ b/tests/fixtures/providers/action/not_a_provider.gd
@@ -1,0 +1,1 @@
+extends RefCounted

--- a/tests/fixtures/providers/action/not_a_provider.gd.uid
+++ b/tests/fixtures/providers/action/not_a_provider.gd.uid
@@ -1,0 +1,1 @@
+uid://buuhi5ie3bpfv

--- a/tests/fixtures/providers/action/valid_action.gd
+++ b/tests/fixtures/providers/action/valid_action.gd
@@ -1,0 +1,7 @@
+extends FKAction
+
+func get_provider_id() -> String:
+	return "valid_action"
+
+func get_supported_types() -> Array[String]:
+	return ["Node"]

--- a/tests/fixtures/providers/action/valid_action.gd.uid
+++ b/tests/fixtures/providers/action/valid_action.gd.uid
@@ -1,0 +1,1 @@
+uid://b1cke5qxxnkr6

--- a/tests/fixtures/providers/action/wrong_kind.gd
+++ b/tests/fixtures/providers/action/wrong_kind.gd
@@ -1,0 +1,4 @@
+extends FKCondition
+
+func get_provider_id() -> String:
+	return "wrong_kind"

--- a/tests/fixtures/providers/action/wrong_kind.gd.uid
+++ b/tests/fixtures/providers/action/wrong_kind.gd.uid
@@ -1,0 +1,1 @@
+uid://1biskf6n7p88

--- a/tests/runtime/unit/test_base_unit.gd
+++ b/tests/runtime/unit/test_base_unit.gd
@@ -9,7 +9,7 @@ func test_fkunit_basic_serialization():
 	var json := unit.serialize()
 
 	assert_eq(json["type"], "event")
-	assert_eq(json["personal_id"], expected_id)
+	assert_eq(json["uid"], expected_id)
 
 
 func test_fkunit_roundtrip():

--- a/tests/runtime/unit/test_provider_base.gd
+++ b/tests/runtime/unit/test_provider_base.gd
@@ -1,0 +1,53 @@
+extends GutTest
+
+class Node2DProvider extends FKProvider:
+	func get_provider_id() -> String:
+		return "node_2d_provider"
+
+	func get_provider_kind() -> String:
+		return KIND_ACTION
+
+	func get_supported_types() -> Array[String]:
+		return ["Node2D"]
+
+class UniversalProvider extends FKProvider:
+	func get_provider_id() -> String:
+		return "universal_provider"
+
+	func get_provider_kind() -> String:
+		return KIND_EVENT
+
+	func get_supported_types() -> Array[String]:
+		return ["Node"]
+
+class InvalidProvider extends FKProvider:
+	func get_inputs() -> Array:
+		return [{"name": "", "type": ""}]
+
+func test_canonical_id_combines_kind_and_provider_id() -> void:
+	var provider := Node2DProvider.new()
+
+	assert_eq(provider.get_canonical_id(), "action:node_2d_provider")
+
+func test_supports_node_class_accepts_inherited_node_type() -> void:
+	var provider := Node2DProvider.new()
+
+	assert_true(provider.supports_node_class("CharacterBody2D"))
+	assert_false(provider.supports_node_class("Control"))
+	assert_false(provider.supports_node_class(""))
+
+func test_node_support_type_matches_every_node_class() -> void:
+	var provider := UniversalProvider.new()
+
+	assert_true(provider.supports_node_class("Node"))
+	assert_true(provider.supports_node_class("CharacterBody2D"))
+	assert_true(provider.supports_node_class("Control"))
+
+func test_validate_definition_reports_missing_provider_metadata() -> void:
+	var provider := InvalidProvider.new()
+	var errors := provider.validate_definition()
+
+	assert_true(errors.has("Provider id is empty."))
+	assert_true(errors.has("Provider kind is empty."))
+	assert_true(errors.has("Input #0 is missing a valid 'name'."))
+	assert_true(errors.has("Input #0 is missing a valid 'type'."))

--- a/tests/runtime/unit/test_provider_base.gd.uid
+++ b/tests/runtime/unit/test_provider_base.gd.uid
@@ -1,0 +1,1 @@
+uid://bfukywmncfuxa

--- a/tests/runtime/unit/test_provider_executor.gd
+++ b/tests/runtime/unit/test_provider_executor.gd
@@ -1,0 +1,108 @@
+extends GutTest
+
+class RecordingAction extends FKAction:
+	var received_node: Node
+	var received_inputs: Dictionary = {}
+	var received_unit_id: int = -1
+
+	func get_provider_id() -> String:
+		return "record_action"
+
+	func get_supported_types() -> Array[String]:
+		return ["Node"]
+
+	func execute(node: Node, inputs: Dictionary, unit_id: int = -1) -> void:
+		received_node = node
+		received_inputs = inputs
+		received_unit_id = unit_id
+
+class RecordingCondition extends FKCondition:
+	var received_inputs: Dictionary = {}
+	var result: bool = true
+
+	func get_provider_id() -> String:
+		return "record_condition"
+
+	func get_supported_types() -> Array[String]:
+		return ["Node"]
+
+	func check(_node: Node, inputs: Dictionary, _unit_id: int = -1) -> bool:
+		received_inputs = inputs
+		return result
+
+class RecordingEvent extends FKEvent:
+	var received_inputs: Dictionary = {}
+
+	func get_provider_id() -> String:
+		return "record_event"
+
+	func get_supported_types() -> Array[String]:
+		return ["Node"]
+
+	func poll(_node: Node, inputs: Dictionary = {}, _unit_id: int = -1) -> bool:
+		received_inputs = inputs
+		return true
+
+class RecordingBehavior extends FKBehavior:
+	var applied_to: Node
+	var applied_inputs: Dictionary = {}
+	var removed_from: Node
+
+	func get_provider_id() -> String:
+		return "record_behavior"
+
+	func get_supported_types() -> Array[String]:
+		return ["Node"]
+
+	func apply(node: Node, inputs: Dictionary) -> void:
+		applied_to = node
+		applied_inputs = inputs
+
+	func remove(node: Node) -> void:
+		removed_from = node
+
+func test_execute_action_evaluates_inputs_and_forwards_unit_id() -> void:
+	var registry := FKRegistry.new()
+	var action := RecordingAction.new()
+	var target_node := Node.new()
+	registry.action_providers.append(action)
+
+	var result = await registry.execute_action("record_action", target_node, {"amount": "21"}, null, 17)
+
+	assert_eq(result, action)
+	assert_eq(action.received_node, target_node)
+	assert_eq(action.received_inputs, {"amount": 21})
+	assert_eq(action.received_unit_id, 17)
+
+func test_check_condition_evaluates_inputs_and_applies_negation() -> void:
+	var registry := FKRegistry.new()
+	var condition := RecordingCondition.new()
+	var target_node := Node.new()
+	registry.condition_providers.append(condition)
+
+	var result := registry.check_condition("record_condition", target_node, {"threshold": "3.5"}, true)
+
+	assert_false(result)
+	assert_eq(condition.received_inputs, {"threshold": 3.5})
+
+func test_poll_event_evaluates_inputs_before_dispatch() -> void:
+	var registry := FKRegistry.new()
+	var event := RecordingEvent.new()
+	var target_node := Node.new()
+	registry.event_providers.append(event)
+
+	assert_true(registry.poll_event("record_event", target_node, {"enabled": "true"}))
+	assert_eq(event.received_inputs, {"enabled": true})
+
+func test_behavior_dispatch_evaluates_apply_inputs_and_forwards_remove() -> void:
+	var registry := FKRegistry.new()
+	var behavior := RecordingBehavior.new()
+	var target_node := Node.new()
+	registry.behavior_providers.append(behavior)
+
+	registry.apply_behavior("record_behavior", target_node, {"speed": "4"})
+	registry.remove_behavior("record_behavior", target_node)
+
+	assert_eq(behavior.applied_to, target_node)
+	assert_eq(behavior.applied_inputs, {"speed": 4})
+	assert_eq(behavior.removed_from, target_node)

--- a/tests/runtime/unit/test_provider_executor.gd.uid
+++ b/tests/runtime/unit/test_provider_executor.gd.uid
@@ -1,0 +1,1 @@
+uid://bgh07bi7jccqh

--- a/tests/runtime/unit/test_provider_loader.gd
+++ b/tests/runtime/unit/test_provider_loader.gd
@@ -1,5 +1,7 @@
 extends GutTest
 
+const ACTION_FIXTURE_PATH := "res://tests/fixtures/providers/action"
+
 func test_loader_returns_fresh_non_accumulating_results() -> void:
 	var loader := FKProviderLoader.new()
 	var first_result := loader.load_all()
@@ -20,3 +22,25 @@ func test_registry_reload_replaces_provider_catalog() -> void:
 	registry.event_providers.size() + registry.behavior_providers.size() + registry.branch_providers.size()
 
 	assert_eq(first_count, second_count)
+
+func test_new_registry_can_dispatch_an_unknown_action() -> void:
+	var registry := FKRegistry.new()
+	var target_node := Node.new()
+
+	var result = await registry.execute_action("missing_action", target_node, {})
+
+	assert_null(result)
+
+func test_loader_filters_invalid_providers_and_reports_duplicates() -> void:
+	var loader := FKProviderLoader.new()
+	loader.provider_paths = {"action": ACTION_FIXTURE_PATH}
+
+	var result := loader.load_all()
+	var diagnostics := "\n".join(result.diagnostics)
+
+	assert_eq(result.source, "directory")
+	assert_eq(result.action_providers.size(), 3)
+	assert_true(diagnostics.contains("does not extend FKProvider"))
+	assert_true(diagnostics.contains("empty id"))
+	assert_true(diagnostics.contains("incompatible action provider type"))
+	assert_true(diagnostics.contains("Duplicate action provider id 'duplicate_action'"))

--- a/tests/runtime/unit/test_provider_loader.gd
+++ b/tests/runtime/unit/test_provider_loader.gd
@@ -1,0 +1,22 @@
+extends GutTest
+
+func test_loader_returns_fresh_non_accumulating_results() -> void:
+	var loader := FKProviderLoader.new()
+	var first_result := loader.load_all()
+	var second_result := loader.load_all()
+
+	assert_ne(first_result, second_result)
+	assert_eq(first_result.source, second_result.source)
+	assert_eq(first_result.get_total_provider_count(), second_result.get_total_provider_count())
+
+func test_registry_reload_replaces_provider_catalog() -> void:
+	var registry := FKRegistry.new()
+	registry.load_all()
+	var first_count := registry.action_providers.size() + registry.condition_providers.size() + \
+	registry.event_providers.size() + registry.behavior_providers.size() + registry.branch_providers.size()
+
+	registry.load_all()
+	var second_count := registry.action_providers.size() + registry.condition_providers.size() + \
+	registry.event_providers.size() + registry.behavior_providers.size() + registry.branch_providers.size()
+
+	assert_eq(first_count, second_count)

--- a/tests/runtime/unit/test_provider_loader.gd.uid
+++ b/tests/runtime/unit/test_provider_loader.gd.uid
@@ -1,0 +1,1 @@
+uid://dw3xliynylcv2

--- a/tests/runtime/unit/test_registry.gd
+++ b/tests/runtime/unit/test_registry.gd
@@ -1,0 +1,74 @@
+extends GutTest
+
+class FixtureAction extends FKAction:
+	var canonical_id: String
+	var legacy_id: String
+	var supported_types: Array[String]
+
+	func _init(p_canonical_id: String, p_legacy_id: String, p_supported_types: Array[String]) -> void:
+		canonical_id = p_canonical_id
+		legacy_id = p_legacy_id
+		supported_types = p_supported_types
+
+	func get_provider_id() -> String:
+		return canonical_id
+
+	func get_id() -> String:
+		return legacy_id
+
+	func get_supported_types() -> Array[String]:
+		return supported_types
+
+class FixtureEvent extends FKEvent:
+	var canonical_id: String
+	var legacy_id: String
+	var supported_types: Array[String]
+
+	func _init(p_canonical_id: String, p_legacy_id: String, p_supported_types: Array[String]) -> void:
+		canonical_id = p_canonical_id
+		legacy_id = p_legacy_id
+		supported_types = p_supported_types
+
+	func get_provider_id() -> String:
+		return canonical_id
+
+	func get_id() -> String:
+		return legacy_id
+
+	func get_supported_types() -> Array[String]:
+		return supported_types
+
+func test_canonical_action_id_takes_precedence_over_legacy_id() -> void:
+	var registry := FKRegistry.new()
+	var legacy_provider := FixtureAction.new("other_action", "shared_action", ["Node"])
+	var canonical_provider := FixtureAction.new("shared_action", "different_legacy", ["Node"])
+	registry.action_providers.append(legacy_provider)
+	registry.action_providers.append(canonical_provider)
+
+	assert_eq(registry.get_action_provider("shared_action"), canonical_provider)
+
+func test_legacy_action_id_uses_the_provider_compatible_with_node_class() -> void:
+	var registry := FKRegistry.new()
+	var control_provider := FixtureAction.new("control_action", "shared_action", ["Control"])
+	var node_2d_provider := FixtureAction.new("node_2d_action", "shared_action", ["Node2D"])
+	registry.action_providers.append(control_provider)
+	registry.action_providers.append(node_2d_provider)
+
+	assert_eq(registry.get_action_provider_for_node_class("shared_action", "CharacterBody2D"), node_2d_provider)
+
+func test_node_class_queries_return_only_compatible_providers() -> void:
+	var registry := FKRegistry.new()
+	var universal_action := FixtureAction.new("any_action", "any_action", ["Node"])
+	var control_action := FixtureAction.new("control_action", "control_action", ["Control"])
+	var timer_event := FixtureEvent.new("timer_event", "timer_event", ["Timer"])
+	registry.action_providers.append(universal_action)
+	registry.action_providers.append(control_action)
+	registry.event_providers.append(timer_event)
+
+	var actions := registry.get_actions_for_node_class("Button")
+	var events := registry.get_events_for_node_class("Timer")
+
+	assert_eq(actions.size(), 2)
+	assert_true(actions.has(universal_action))
+	assert_true(actions.has(control_action))
+	assert_eq(events, [timer_event])

--- a/tests/runtime/unit/test_registry.gd.uid
+++ b/tests/runtime/unit/test_registry.gd.uid
@@ -1,0 +1,1 @@
+uid://0pvvrdlrwfmi


### PR DESCRIPTION
## Summary
This PR modernizes several legacy API usages, fixes regressions introduced by a previous change, and improves the provider architecture by splitting `FKRegistry` into more focused components.

### Key Changes
- Replaced some legacy API usage with modern equivalents
- Fixed regressions from the previous PR
- Tightened typing to reduce duck typing and remove redundant `has_method` checks
- Improved provider management modularity
- Split `FKRegistry` responsibilities into dedicated classes for cleaner separation of concerns

### Bug fixes
- Fixed action names in the Select Action Modal showing as **"Invalid"**
- Restored backward compatibility for the **Print Message** action

### Modularity Changes
Responsibilities moved out of `FKRegistry` into new classes:

#### `FKProviderLoader`
- Manifest loading
- Editor directory scanning
- Provider instantiation
- Abstract/type/id validation
- Duplicate ID reporting

#### `FKProviderExecutor`
- Event polling, setup, teardown, and signal-event checks
- Condition evaluation and negation
- Action execution, expression evaluation, and multi-frame completion state
- Behavior application/removal
- Branch input validation

`FKRegistry` now delegates these responsibilities to the new classes, improving structure and making the codebase easier to maintain.

### Additional changes
- Added `FKProviderLoadResult` as a helper for provider loading results
- Updated modal windows to defer provider loading to `FKRegistry`
  - This should improve performance by avoiding repeated provider loading each time a modal opens

### Tests Added
This PR adds coverage for:
- Provider-loading idempotency
- Provider lookup
- Provider execution

## Other Notes
You can see the non-rebased versions of the commits in the providerManagement_02_bak branch on my fork.